### PR TITLE
Add "InProgress" condition both on Plan creation and upgrade validation steps

### DIFF
--- a/internal/controller/reconcile_kubernetes.go
+++ b/internal/controller/reconcile_kubernetes.go
@@ -56,7 +56,7 @@ func (r *UpgradePlanReconciler) reconcileKubernetes(ctx context.Context, upgrade
 			return ctrl.Result{}, err
 		}
 
-		setInProgressCondition(upgradePlan, lifecyclev1alpha1.KubernetesUpgradedCondition, "Control plane nodes are being upgraded")
+		setInProgressCondition(upgradePlan, lifecyclev1alpha1.KubernetesUpgradedCondition, "Worker nodes are being upgraded")
 		return ctrl.Result{}, r.createPlan(ctx, upgradePlan, workerPlan)
 	}
 

--- a/internal/controller/reconcile_kubernetes.go
+++ b/internal/controller/reconcile_kubernetes.go
@@ -33,6 +33,7 @@ func (r *UpgradePlanReconciler) reconcileKubernetes(ctx context.Context, upgrade
 			return ctrl.Result{}, err
 		}
 
+		setInProgressCondition(upgradePlan, lifecyclev1alpha1.KubernetesUpgradedCondition, "Control plane nodes are being upgraded")
 		return ctrl.Result{}, r.createPlan(ctx, upgradePlan, controlPlanePlan)
 	}
 
@@ -55,6 +56,7 @@ func (r *UpgradePlanReconciler) reconcileKubernetes(ctx context.Context, upgrade
 			return ctrl.Result{}, err
 		}
 
+		setInProgressCondition(upgradePlan, lifecyclev1alpha1.KubernetesUpgradedCondition, "Control plane nodes are being upgraded")
 		return ctrl.Result{}, r.createPlan(ctx, upgradePlan, workerPlan)
 	}
 

--- a/internal/controller/reconcile_os.go
+++ b/internal/controller/reconcile_os.go
@@ -51,6 +51,7 @@ func (r *UpgradePlanReconciler) reconcileOS(ctx context.Context, upgradePlan *li
 	}
 
 	if !isOSUpgraded(nodeList, selector, release.Components.OperatingSystem.PrettyName) {
+		setInProgressCondition(upgradePlan, lifecyclev1alpha1.OperatingSystemUpgradedCondition, "Control plane nodes are being upgraded")
 		return ctrl.Result{}, nil
 	} else if controlPlaneOnlyCluster(nodeList) {
 		setSuccessfulCondition(upgradePlan, lifecyclev1alpha1.OperatingSystemUpgradedCondition, "All cluster nodes are upgraded")


### PR DESCRIPTION
Now that we do not reconcile when an SUC Plan is created, we need to ad the "InProgress" condition during the SUC Plan creation.

We also update the timestamps for the "InProgress" condition when we do a validation of the specific component upgrade.