### PR TITLE
OS upgrade implementation for multi node clusters

### DIFF
--- a/internal/controller/reconcile_os.go
+++ b/internal/controller/reconcile_os.go
@@ -74,7 +74,7 @@ func (r *UpgradePlanReconciler) reconcileOS(ctx context.Context, upgradePlan *li
 	}
 
 	if !isOSUpgraded(nodeList, selector, release.Components.OperatingSystem.PrettyName) {
-		setInProgressCondition(upgradePlan, lifecyclev1alpha1.OperatingSystemUpgradedCondition, "Control plane nodes are being upgraded")
+		setInProgressCondition(upgradePlan, lifecyclev1alpha1.OperatingSystemUpgradedCondition, "Worker nodes are being upgraded")
 		return ctrl.Result{}, nil
 	}
 

--- a/internal/controller/reconcile_os.go
+++ b/internal/controller/reconcile_os.go
@@ -15,7 +15,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-//lint:ignore U1000 - Temporary ignore "unused" linter error. Will be removed when function is ready to be used.
 func (r *UpgradePlanReconciler) reconcileOS(ctx context.Context, upgradePlan *lifecyclev1alpha1.UpgradePlan, release *release.Release) (ctrl.Result, error) {
 	secret, err := upgrade.OSUpgradeSecret(&release.Components.OperatingSystem)
 	if err != nil {
@@ -64,7 +63,7 @@ func (r *UpgradePlanReconciler) reconcileOS(ctx context.Context, upgradePlan *li
 			return ctrl.Result{}, err
 		}
 
-		setInProgressCondition(upgradePlan, lifecyclev1alpha1.OperatingSystemUpgradedCondition, "Control plane nodes are being upgraded")
+		setInProgressCondition(upgradePlan, lifecyclev1alpha1.OperatingSystemUpgradedCondition, "Worker nodes are being upgraded")
 		return ctrl.Result{}, r.createPlan(ctx, upgradePlan, workerPlan)
 	}
 

--- a/internal/controller/reconcile_os.go
+++ b/internal/controller/reconcile_os.go
@@ -58,7 +58,27 @@ func (r *UpgradePlanReconciler) reconcileOS(ctx context.Context, upgradePlan *li
 		return ctrl.Result{Requeue: true}, nil
 	}
 
-	// TODO: worker upgrade
+	workerPlan := upgrade.OSWorkerPlan(release.ReleaseVersion, secret.Name, &release.Components.OperatingSystem)
+	if err = r.Get(ctx, client.ObjectKeyFromObject(workerPlan), workerPlan); err != nil {
+		if !errors.IsNotFound(err) {
+			return ctrl.Result{}, err
+		}
+
+		setInProgressCondition(upgradePlan, lifecyclev1alpha1.OperatingSystemUpgradedCondition, "Control plane nodes are being upgraded")
+		return ctrl.Result{}, r.createPlan(ctx, upgradePlan, workerPlan)
+	}
+
+	selector, err = metav1.LabelSelectorAsSelector(workerPlan.Spec.NodeSelector)
+	if err != nil {
+		return ctrl.Result{}, fmt.Errorf("parsing node selector: %w", err)
+	}
+
+	if !isOSUpgraded(nodeList, selector, release.Components.OperatingSystem.PrettyName) {
+		setInProgressCondition(upgradePlan, lifecyclev1alpha1.OperatingSystemUpgradedCondition, "Control plane nodes are being upgraded")
+		return ctrl.Result{}, nil
+	}
+
+	setSuccessfulCondition(upgradePlan, lifecyclev1alpha1.OperatingSystemUpgradedCondition, "All cluster nodes are upgraded")
 	return ctrl.Result{Requeue: true}, nil
 }
 

--- a/internal/controller/upgradeplan_controller.go
+++ b/internal/controller/upgradeplan_controller.go
@@ -98,9 +98,8 @@ func (r *UpgradePlanReconciler) executePlan(ctx context.Context, upgradePlan *li
 	}
 
 	switch {
-	// TODO: uncomment once OS upgrades support multi node clusters
-	// case !meta.IsStatusConditionTrue(upgradePlan.Status.Conditions, lifecyclev1alpha1.OperatingSystemUpgradedCondition):
-	// 	return r.reconcileOS(ctx, upgradePlan, release)
+	case !meta.IsStatusConditionTrue(upgradePlan.Status.Conditions, lifecyclev1alpha1.OperatingSystemUpgradedCondition):
+		return r.reconcileOS(ctx, upgradePlan, release)
 	case !meta.IsStatusConditionTrue(upgradePlan.Status.Conditions, lifecyclev1alpha1.KubernetesUpgradedCondition):
 		return r.reconcileKubernetes(ctx, upgradePlan, &release.Components.Kubernetes)
 	case !isHelmUpgradeFinished(upgradePlan, lifecyclev1alpha1.RancherUpgradedCondition):


### PR DESCRIPTION
Introduces implementation for handling OS upgrades over clusters consisting of multiple nodes.

Tested for:
1. 5.5 OS package upgrade 
2. 5.5 -> 6.0 OS migration + K8s upgrade + Rancher upgrade 

Benchmarks:
- For (1) ~ 30 minutes for all packages of all nodes to be upgraded
- For (2) ~ a little over an hour for everything

Migration screenshots:
Before:
![Screenshot 2024-07-29 at 12 35 37](https://github.com/user-attachments/assets/22bf6c87-c12d-4533-9e2b-36e71e190997)

After:
![Screenshot 2024-07-29 at 13 54 44](https://github.com/user-attachments/assets/3dbff53b-0e44-4a3d-a3b8-7f2bbbf1dc12)

UpgradePlan Conditions:
![Screenshot 2024-07-29 at 13 57 06](https://github.com/user-attachments/assets/23d5351b-c479-4d30-930c-1cdd527d8bb9)

Note:
- **Node drain** logic is not part of this PR, it will come next as it requires more testing

Known **non-blocking** issues:

Currently the 5.5 -> 6.0 migration produces the following error once all packages have been installed:
>Can't determine the list of installed products after migration: Get "https://scc.suse.com/connect/systems/activations": dial tcp: lookup scc.suse.com on [::1]:53: read udp [::1]:43295->[::1]:53: read: connection refused

This error is caused by the `transactional-update run zypper migration ...` command and does not block the system's successful migration. The error is not bound to the suggested code here and is reproducible outside of any upgrade-controller code.

This error is non-existent when running `transactional-update migration`, so the problem should be mitigated once we move to `transactional-update migration`. This will happen when `transactional-update migration` support the needed `zypper migration` flags so that the migration can be automated. Currently this is not the case.