### PR TITLE
Skip chart version upgrades between identical releases

### DIFF
--- a/internal/controller/helm.go
+++ b/internal/controller/helm.go
@@ -66,6 +66,7 @@ func (r *UpgradePlanReconciler) updateHelmChart(ctx context.Context, upgradePlan
 		chart.Annotations = map[string]string{}
 	}
 	chart.Annotations[upgrade.PlanAnnotation] = upgradePlan.Name
+	chart.Annotations[upgrade.ReleaseAnnotation] = upgradePlan.Spec.ReleaseVersion
 	chart.Spec.ChartContent = ""
 	chart.Spec.Chart = releaseChart.Name
 	chart.Spec.Version = releaseChart.Version
@@ -77,7 +78,7 @@ func (r *UpgradePlanReconciler) updateHelmChart(ctx context.Context, upgradePlan
 
 // Creates a HelmChart resource in order to trigger an upgrade
 // using the information from an existing Helm release.
-func (r *UpgradePlanReconciler) createHelmChart(ctx context.Context, releaseChart *release.HelmChart, installedChart *helmrelease.Release, upgradePlanName string) error {
+func (r *UpgradePlanReconciler) createHelmChart(ctx context.Context, upgradePlan *lifecyclev1alpha1.UpgradePlan, installedChart *helmrelease.Release, releaseChart *release.HelmChart) error {
 	backoffLimit := int32(6)
 	var values []byte
 
@@ -99,7 +100,8 @@ func (r *UpgradePlanReconciler) createHelmChart(ctx context.Context, releaseChar
 			Name:      releaseChart.Name,
 			Namespace: upgrade.ChartNamespace,
 			Annotations: map[string]string{
-				upgrade.PlanAnnotation: upgradePlanName,
+				upgrade.PlanAnnotation:    upgradePlan.Name,
+				upgrade.ReleaseAnnotation: upgradePlan.Spec.ReleaseVersion,
 			},
 		},
 		Spec: helmcattlev1.HelmChartSpec{

--- a/internal/controller/upgradeplan_controller.go
+++ b/internal/controller/upgradeplan_controller.go
@@ -191,6 +191,10 @@ func setSkippedCondition(plan *lifecyclev1alpha1.UpgradePlan, conditionType, mes
 	meta.SetStatusCondition(&plan.Status.Conditions, condition)
 }
 
+func versionAlreadyInstalledMessage(plan *lifecyclev1alpha1.UpgradePlan) string {
+	return fmt.Sprintf("Component version is the same in release %s", plan.Spec.ReleaseVersion)
+}
+
 func (r *UpgradePlanReconciler) findUpgradePlanFromJob(ctx context.Context, job client.Object) []reconcile.Request {
 	jobLabels := job.GetLabels()
 	chartName, ok := jobLabels[chart.Label]

--- a/internal/upgrade/base.go
+++ b/internal/upgrade/base.go
@@ -7,10 +7,11 @@ import (
 )
 
 const (
-	planNamespace   = "cattle-system"
-	PlanAnnotation  = "lifecycle.suse.com/upgrade-plan"
-	controlPlaneKey = "control-plane"
-	workersKey      = "workers"
+	planNamespace     = "cattle-system"
+	PlanAnnotation    = "lifecycle.suse.com/upgrade-plan"
+	ReleaseAnnotation = "lifecycle.suse.com/release"
+	controlPlaneKey   = "control-plane"
+	workersKey        = "workers"
 
 	ControlPlaneLabel = "node-role.kubernetes.io/control-plane"
 )


### PR DESCRIPTION
- Chart versions may not change between different releases
- Introduce an annotation to the `HelmChart` resource in order to differentiate whether an upgrade was just triggered or if it should be skipped