### PR TITLE
Add drain logic for upgrade-controller SUC plans

### DIFF
--- a/api/v1alpha1/upgradeplan_types.go
+++ b/api/v1alpha1/upgradeplan_types.go
@@ -48,6 +48,15 @@ type UpgradePlanSpec struct {
 	// ReleaseVersion specifies the target version for platform upgrade.
 	// The version format is X.Y.Z, for example "3.0.2".
 	ReleaseVersion string `json:"releaseVersion"`
+	// +optional
+	Drain *Drain `json:"drain"`
+}
+
+type Drain struct {
+	// +optional
+	ControlPlanes *bool `json:"controlPlanes"`
+	// +optional
+	Workers *bool `json:"workers"`
 }
 
 // UpgradePlanStatus defines the observed state of UpgradePlan

--- a/api/v1alpha1/upgradeplan_types.go
+++ b/api/v1alpha1/upgradeplan_types.go
@@ -48,6 +48,8 @@ type UpgradePlanSpec struct {
 	// ReleaseVersion specifies the target version for platform upgrade.
 	// The version format is X.Y.Z, for example "3.0.2".
 	ReleaseVersion string `json:"releaseVersion"`
+	// Drain specifies whether control-plane and worker nodes should be drained.
+	// If left unspecified, drain is done on both control-plane and worker nodes by default.
 	// +optional
 	Drain *Drain `json:"drain"`
 }

--- a/api/v1alpha1/upgradeplan_types.go
+++ b/api/v1alpha1/upgradeplan_types.go
@@ -56,9 +56,9 @@ type UpgradePlanSpec struct {
 
 type Drain struct {
 	// +optional
-	ControlPlanes *bool `json:"controlPlanes"`
+	ControlPlane *bool `json:"controlPlane"`
 	// +optional
-	Workers *bool `json:"workers"`
+	Worker *bool `json:"worker"`
 }
 
 // UpgradePlanStatus defines the observed state of UpgradePlan

--- a/config/crd/bases/lifecycle.suse.com_upgradeplans.yaml
+++ b/config/crd/bases/lifecycle.suse.com_upgradeplans.yaml
@@ -44,9 +44,9 @@ spec:
                   Drain specifies whether control-plane and worker nodes should be drained.
                   If left unspecified, drain is done on both control-plane and worker nodes by default.
                 properties:
-                  controlPlanes:
+                  controlPlane:
                     type: boolean
-                  workers:
+                  worker:
                     type: boolean
                 type: object
               releaseVersion:

--- a/config/crd/bases/lifecycle.suse.com_upgradeplans.yaml
+++ b/config/crd/bases/lifecycle.suse.com_upgradeplans.yaml
@@ -40,6 +40,9 @@ spec:
             description: UpgradePlanSpec defines the desired state of UpgradePlan
             properties:
               drain:
+                description: |-
+                  Drain specifies whether control-plane and worker nodes should be drained.
+                  If left unspecified, drain is done on both control-plane and worker nodes by default.
                 properties:
                   controlPlanes:
                     type: boolean

--- a/config/crd/bases/lifecycle.suse.com_upgradeplans.yaml
+++ b/config/crd/bases/lifecycle.suse.com_upgradeplans.yaml
@@ -39,6 +39,13 @@ spec:
           spec:
             description: UpgradePlanSpec defines the desired state of UpgradePlan
             properties:
+              drain:
+                properties:
+                  controlPlanes:
+                    type: boolean
+                  workers:
+                    type: boolean
+                type: object
               releaseVersion:
                 description: |-
                   ReleaseVersion specifies the target version for platform upgrade.

--- a/internal/controller/reconcile_kubernetes.go
+++ b/internal/controller/reconcile_kubernetes.go
@@ -27,8 +27,8 @@ func (r *UpgradePlanReconciler) reconcileKubernetes(ctx context.Context, upgrade
 		return ctrl.Result{}, fmt.Errorf("identifying target kubernetes version: %w", err)
 	}
 
-	drainControlPlanes, drainWorkers := parseDrainOptions(upgradePlan)
-	controlPlanePlan := upgrade.KubernetesControlPlanePlan(kubernetesVersion, drainControlPlanes)
+	drainControlPlane, drainWorker := parseDrainOptions(upgradePlan)
+	controlPlanePlan := upgrade.KubernetesControlPlanePlan(kubernetesVersion, drainControlPlane)
 	if err = r.Get(ctx, client.ObjectKeyFromObject(controlPlanePlan), controlPlanePlan); err != nil {
 		if !errors.IsNotFound(err) {
 			return ctrl.Result{}, err
@@ -51,7 +51,7 @@ func (r *UpgradePlanReconciler) reconcileKubernetes(ctx context.Context, upgrade
 		return ctrl.Result{Requeue: true}, nil
 	}
 
-	workerPlan := upgrade.KubernetesWorkerPlan(kubernetesVersion, drainWorkers)
+	workerPlan := upgrade.KubernetesWorkerPlan(kubernetesVersion, drainWorker)
 	if err = r.Get(ctx, client.ObjectKeyFromObject(workerPlan), workerPlan); err != nil {
 		if !errors.IsNotFound(err) {
 			return ctrl.Result{}, err

--- a/internal/controller/reconcile_kubernetes.go
+++ b/internal/controller/reconcile_kubernetes.go
@@ -27,7 +27,8 @@ func (r *UpgradePlanReconciler) reconcileKubernetes(ctx context.Context, upgrade
 		return ctrl.Result{}, fmt.Errorf("identifying target kubernetes version: %w", err)
 	}
 
-	controlPlanePlan := upgrade.KubernetesControlPlanePlan(kubernetesVersion)
+	drainControlPlanes, drainWorkers := parseDrainOptions(upgradePlan)
+	controlPlanePlan := upgrade.KubernetesControlPlanePlan(kubernetesVersion, drainControlPlanes)
 	if err = r.Get(ctx, client.ObjectKeyFromObject(controlPlanePlan), controlPlanePlan); err != nil {
 		if !errors.IsNotFound(err) {
 			return ctrl.Result{}, err
@@ -50,7 +51,7 @@ func (r *UpgradePlanReconciler) reconcileKubernetes(ctx context.Context, upgrade
 		return ctrl.Result{Requeue: true}, nil
 	}
 
-	workerPlan := upgrade.KubernetesWorkerPlan(kubernetesVersion)
+	workerPlan := upgrade.KubernetesWorkerPlan(kubernetesVersion, drainWorkers)
 	if err = r.Get(ctx, client.ObjectKeyFromObject(workerPlan), workerPlan); err != nil {
 		if !errors.IsNotFound(err) {
 			return ctrl.Result{}, err

--- a/internal/controller/reconcile_os.go
+++ b/internal/controller/reconcile_os.go
@@ -29,8 +29,8 @@ func (r *UpgradePlanReconciler) reconcileOS(ctx context.Context, upgradePlan *li
 		return ctrl.Result{}, r.createSecret(ctx, upgradePlan, secret)
 	}
 
-	drainControlPlanes, drainWorkers := parseDrainOptions(upgradePlan)
-	controlPlanePlan := upgrade.OSControlPlanePlan(release.ReleaseVersion, secret.Name, &release.Components.OperatingSystem, drainControlPlanes)
+	drainControlPlane, drainWorker := parseDrainOptions(upgradePlan)
+	controlPlanePlan := upgrade.OSControlPlanePlan(release.ReleaseVersion, secret.Name, &release.Components.OperatingSystem, drainControlPlane)
 	if err = r.Get(ctx, client.ObjectKeyFromObject(controlPlanePlan), controlPlanePlan); err != nil {
 		if !errors.IsNotFound(err) {
 			return ctrl.Result{}, err
@@ -58,7 +58,7 @@ func (r *UpgradePlanReconciler) reconcileOS(ctx context.Context, upgradePlan *li
 		return ctrl.Result{Requeue: true}, nil
 	}
 
-	workerPlan := upgrade.OSWorkerPlan(release.ReleaseVersion, secret.Name, &release.Components.OperatingSystem, drainWorkers)
+	workerPlan := upgrade.OSWorkerPlan(release.ReleaseVersion, secret.Name, &release.Components.OperatingSystem, drainWorker)
 	if err = r.Get(ctx, client.ObjectKeyFromObject(workerPlan), workerPlan); err != nil {
 		if !errors.IsNotFound(err) {
 			return ctrl.Result{}, err

--- a/internal/controller/reconcile_os.go
+++ b/internal/controller/reconcile_os.go
@@ -29,7 +29,8 @@ func (r *UpgradePlanReconciler) reconcileOS(ctx context.Context, upgradePlan *li
 		return ctrl.Result{}, r.createSecret(ctx, upgradePlan, secret)
 	}
 
-	controlPlanePlan := upgrade.OSControlPlanePlan(release.ReleaseVersion, secret.Name, &release.Components.OperatingSystem)
+	drainControlPlanes, drainWorkers := parseDrainOptions(upgradePlan)
+	controlPlanePlan := upgrade.OSControlPlanePlan(release.ReleaseVersion, secret.Name, &release.Components.OperatingSystem, drainControlPlanes)
 	if err = r.Get(ctx, client.ObjectKeyFromObject(controlPlanePlan), controlPlanePlan); err != nil {
 		if !errors.IsNotFound(err) {
 			return ctrl.Result{}, err
@@ -57,7 +58,7 @@ func (r *UpgradePlanReconciler) reconcileOS(ctx context.Context, upgradePlan *li
 		return ctrl.Result{Requeue: true}, nil
 	}
 
-	workerPlan := upgrade.OSWorkerPlan(release.ReleaseVersion, secret.Name, &release.Components.OperatingSystem)
+	workerPlan := upgrade.OSWorkerPlan(release.ReleaseVersion, secret.Name, &release.Components.OperatingSystem, drainWorkers)
 	if err = r.Get(ctx, client.ObjectKeyFromObject(workerPlan), workerPlan); err != nil {
 		if !errors.IsNotFound(err) {
 			return ctrl.Result{}, err

--- a/internal/controller/upgradeplan_controller.go
+++ b/internal/controller/upgradeplan_controller.go
@@ -166,6 +166,23 @@ func isHelmUpgradeFinished(plan *lifecyclev1alpha1.UpgradePlan, conditionType st
 	return false
 }
 
+func parseDrainOptions(plan *lifecyclev1alpha1.UpgradePlan) (drainControlPlanes bool, drainWorkers bool) {
+	drainControlPlanes = true
+	drainWorkers = true
+
+	if plan.Spec.Drain != nil {
+		if plan.Spec.Drain.ControlPlanes != nil {
+			drainControlPlanes = *plan.Spec.Drain.ControlPlanes
+		}
+
+		if plan.Spec.Drain.Workers != nil {
+			drainWorkers = *plan.Spec.Drain.Workers
+		}
+	}
+
+	return drainControlPlanes, drainWorkers
+}
+
 func setPendingCondition(plan *lifecyclev1alpha1.UpgradePlan, conditionType, message string) {
 	condition := metav1.Condition{Type: conditionType, Status: metav1.ConditionUnknown, Reason: lifecyclev1alpha1.UpgradePending, Message: message}
 	meta.SetStatusCondition(&plan.Status.Conditions, condition)

--- a/internal/controller/upgradeplan_controller.go
+++ b/internal/controller/upgradeplan_controller.go
@@ -166,21 +166,21 @@ func isHelmUpgradeFinished(plan *lifecyclev1alpha1.UpgradePlan, conditionType st
 	return false
 }
 
-func parseDrainOptions(plan *lifecyclev1alpha1.UpgradePlan) (drainControlPlanes bool, drainWorkers bool) {
-	drainControlPlanes = true
-	drainWorkers = true
+func parseDrainOptions(plan *lifecyclev1alpha1.UpgradePlan) (drainControlPlane bool, drainWorker bool) {
+	drainControlPlane = true
+	drainWorker = true
 
 	if plan.Spec.Drain != nil {
-		if plan.Spec.Drain.ControlPlanes != nil {
-			drainControlPlanes = *plan.Spec.Drain.ControlPlanes
+		if plan.Spec.Drain.ControlPlane != nil {
+			drainControlPlane = *plan.Spec.Drain.ControlPlane
 		}
 
-		if plan.Spec.Drain.Workers != nil {
-			drainWorkers = *plan.Spec.Drain.Workers
+		if plan.Spec.Drain.Worker != nil {
+			drainWorker = *plan.Spec.Drain.Worker
 		}
 	}
 
-	return drainControlPlanes, drainWorkers
+	return drainControlPlane, drainWorker
 }
 
 func setPendingCondition(plan *lifecyclev1alpha1.UpgradePlan, conditionType, message string) {

--- a/internal/upgrade/base.go
+++ b/internal/upgrade/base.go
@@ -1,6 +1,8 @@
 package upgrade
 
 import (
+	"time"
+
 	upgradecattlev1 "github.com/rancher/system-upgrade-controller/pkg/apis/upgrade.cattle.io/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -16,7 +18,7 @@ const (
 	ControlPlaneLabel = "node-role.kubernetes.io/control-plane"
 )
 
-func baseUpgradePlan(name string) *upgradecattlev1.Plan {
+func baseUpgradePlan(name string, drain bool) *upgradecattlev1.Plan {
 	const (
 		kind               = "Plan"
 		apiVersion         = "upgrade.cattle.io/v1"
@@ -35,6 +37,18 @@ func baseUpgradePlan(name string) *upgradecattlev1.Plan {
 		Spec: upgradecattlev1.PlanSpec{
 			ServiceAccountName: serviceAccountName,
 		},
+	}
+
+	if drain {
+		timeout := 15 * time.Minute
+		deleteEmptyDirData := true
+		ignoreDaemonSets := true
+		plan.Spec.Drain = &upgradecattlev1.DrainSpec{
+			Timeout:            &timeout,
+			DeleteEmptydirData: &deleteEmptyDirData,
+			IgnoreDaemonSets:   &ignoreDaemonSets,
+			Force:              true,
+		}
 	}
 
 	return plan

--- a/internal/upgrade/kubernetes.go
+++ b/internal/upgrade/kubernetes.go
@@ -26,11 +26,11 @@ func kubernetesUpgradeImage(version string) string {
 	return rke2UpgradeImage
 }
 
-func KubernetesControlPlanePlan(version string) *upgradecattlev1.Plan {
+func KubernetesControlPlanePlan(version string, drain bool) *upgradecattlev1.Plan {
 	controlPlanePlanName := kubernetesPlanName(controlPlaneKey, version)
 	upgradeImage := kubernetesUpgradeImage(version)
 
-	controlPlanePlan := baseUpgradePlan(controlPlanePlanName)
+	controlPlanePlan := baseUpgradePlan(controlPlanePlanName, drain)
 	controlPlanePlan.Labels = map[string]string{
 		"k8s-upgrade": "control-plane",
 	}
@@ -75,12 +75,12 @@ func KubernetesControlPlanePlan(version string) *upgradecattlev1.Plan {
 	return controlPlanePlan
 }
 
-func KubernetesWorkerPlan(version string) *upgradecattlev1.Plan {
+func KubernetesWorkerPlan(version string, drain bool) *upgradecattlev1.Plan {
 	controlPlanePlanName := kubernetesPlanName(controlPlaneKey, version)
 	workerPlanName := kubernetesPlanName(workersKey, version)
 	upgradeImage := kubernetesUpgradeImage(version)
 
-	workerPlan := baseUpgradePlan(workerPlanName)
+	workerPlan := baseUpgradePlan(workerPlanName, drain)
 	workerPlan.Labels = map[string]string{
 		"k8s-upgrade": "worker",
 	}
@@ -108,9 +108,6 @@ func KubernetesWorkerPlan(version string) *upgradecattlev1.Plan {
 	}
 	workerPlan.Spec.Version = version
 	workerPlan.Spec.Cordon = true
-	workerPlan.Spec.Drain = &upgradecattlev1.DrainSpec{
-		Force: true,
-	}
 
 	return workerPlan
 }

--- a/internal/upgrade/os.go
+++ b/internal/upgrade/os.go
@@ -64,9 +64,9 @@ func OSUpgradeSecret(releaseOS *release.OperatingSystem) (*corev1.Secret, error)
 	return secret, nil
 }
 
-func OSControlPlanePlan(releaseVersion, secretName string, releaseOS *release.OperatingSystem) *upgradecattlev1.Plan {
+func OSControlPlanePlan(releaseVersion, secretName string, releaseOS *release.OperatingSystem, drain bool) *upgradecattlev1.Plan {
 	controlPlanePlanName := osPlanName(controlPlaneKey, releaseOS.ZypperID, releaseOS.Version)
-	controlPlanePlan := baseOSPlan(controlPlanePlanName, releaseVersion, secretName)
+	controlPlanePlan := baseOSPlan(controlPlanePlanName, releaseVersion, secretName, drain)
 
 	controlPlanePlan.Labels = map[string]string{
 		"os-upgrade": "control-plane",
@@ -107,9 +107,9 @@ func OSControlPlanePlan(releaseVersion, secretName string, releaseOS *release.Op
 	return controlPlanePlan
 }
 
-func OSWorkerPlan(releaseVersion, secretName string, releaseOS *release.OperatingSystem) *upgradecattlev1.Plan {
+func OSWorkerPlan(releaseVersion, secretName string, releaseOS *release.OperatingSystem, drain bool) *upgradecattlev1.Plan {
 	workerPlanName := osPlanName(workersKey, releaseOS.ZypperID, releaseOS.Version)
-	workerPlan := baseOSPlan(workerPlanName, releaseVersion, secretName)
+	workerPlan := baseOSPlan(workerPlanName, releaseVersion, secretName, drain)
 
 	workerPlan.Labels = map[string]string{
 		"os-upgrade": "worker",
@@ -131,12 +131,12 @@ func OSWorkerPlan(releaseVersion, secretName string, releaseOS *release.Operatin
 	return workerPlan
 }
 
-func baseOSPlan(planName, releaseVersion, secretName string) *upgradecattlev1.Plan {
+func baseOSPlan(planName, releaseVersion, secretName string, drain bool) *upgradecattlev1.Plan {
 	const (
 		planImage = "registry.suse.com/bci/bci-base:15.5"
 	)
 
-	baseOSplan := baseUpgradePlan(planName)
+	baseOSplan := baseUpgradePlan(planName, drain)
 
 	secretPathRelativeToHost := fmt.Sprintf("/run/system-upgrade/secrets/%s", secretName)
 	mountPath := filepath.Join("/host", secretPathRelativeToHost)


### PR DESCRIPTION
As discussed previously the upgrade-controller should:
1. Drain the control-plane and worker nodes for both K8s and OS upgrades
2. Offer the possibility to disable node drain for control-plane/worker nodes or disable the whole node drain procedure of the upgrade-controller

By default the upgrade-controller will execute drain with the following flags:
- `--delete-emptydir-data` - continue drain even if there are pods utilising `emptyDir` storage
-  `--timeout 15m0s` - the amount of time for which to wait for the drain operation to finish. Ensures that the drain operation will not block the upgrade flow
- `--ignore-daemonsets` - ignores DaemonSet-managed pods
- `--force` - continue even if there are pods that do not have a controller (single pods)

Due to the nature of how we do upgrades, node drain will happen twice - once during OS upgrades and once during K8s upgrades.

Tested scenarios:
- Full node drain on a single cluster
- Full node drain on a HA cluster
- Worker only node drain on a HA cluster
- Control-plane only node drain on a HA cluster