### PR TITLE
Upgrade MetalLB

### DIFF
--- a/api/v1alpha1/upgradeplan_types.go
+++ b/api/v1alpha1/upgradeplan_types.go
@@ -26,6 +26,7 @@ const (
 	KubernetesUpgradedCondition = "KubernetesUpgraded"
 	RancherUpgradedCondition    = "RancherUpgraded"
 	LonghornUpgradedCondition   = "LonghornUpgraded"
+	MetalLBUpgradedCondition    = "MetalLBUpgraded"
 
 	// UpgradeError indicates that the upgrade process has encountered a transient error.
 	UpgradeError = "Error"

--- a/internal/controller/helm.go
+++ b/internal/controller/helm.go
@@ -125,8 +125,7 @@ func (r *UpgradePlanReconciler) createHelmChart(ctx context.Context, upgradePlan
 }
 
 func (r *UpgradePlanReconciler) upgradeHelmChart(ctx context.Context, upgradePlan *lifecyclev1alpha1.UpgradePlan, releaseChart *release.HelmChart) (upgrade.HelmChartState, error) {
-	helmReleaseName := retrieveHelmReleaseName(releaseChart)
-	helmRelease, err := retrieveHelmRelease(helmReleaseName)
+	helmRelease, err := retrieveHelmRelease(releaseChart.ReleaseName)
 	if err != nil {
 		if errors.Is(err, helmdriver.ErrReleaseNotFound) {
 			return upgrade.ChartStateNotInstalled, nil
@@ -184,14 +183,6 @@ func (r *UpgradePlanReconciler) upgradeHelmChart(ctx context.Context, upgradePla
 		"jobStatus", condition.Message)
 
 	return upgrade.ChartStateFailed, nil
-}
-
-func retrieveHelmReleaseName(releaseChart *release.HelmChart) string {
-	if releaseChart.ReleaseName != "" {
-		return releaseChart.ReleaseName
-	}
-
-	return releaseChart.Name
 }
 
 func evaluateHelmChartState(state upgrade.HelmChartState) (setCondition setCondition, requeue bool) {

--- a/internal/controller/helm.go
+++ b/internal/controller/helm.go
@@ -125,7 +125,8 @@ func (r *UpgradePlanReconciler) createHelmChart(ctx context.Context, upgradePlan
 }
 
 func (r *UpgradePlanReconciler) upgradeHelmChart(ctx context.Context, upgradePlan *lifecyclev1alpha1.UpgradePlan, releaseChart *release.HelmChart) (upgrade.HelmChartState, error) {
-	helmRelease, err := retrieveHelmRelease(releaseChart.Name)
+	helmReleaseName := retrieveHelmReleaseName(releaseChart)
+	helmRelease, err := retrieveHelmRelease(helmReleaseName)
 	if err != nil {
 		if errors.Is(err, helmdriver.ErrReleaseNotFound) {
 			return upgrade.ChartStateNotInstalled, nil
@@ -183,6 +184,14 @@ func (r *UpgradePlanReconciler) upgradeHelmChart(ctx context.Context, upgradePla
 		"jobStatus", condition.Message)
 
 	return upgrade.ChartStateFailed, nil
+}
+
+func retrieveHelmReleaseName(releaseChart *release.HelmChart) string {
+	if releaseChart.ReleaseName != "" {
+		return releaseChart.ReleaseName
+	}
+
+	return releaseChart.Name
 }
 
 func evaluateHelmChartState(state upgrade.HelmChartState) (setCondition setCondition, requeue bool) {

--- a/internal/controller/helm.go
+++ b/internal/controller/helm.go
@@ -23,6 +23,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/config"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 )
@@ -158,7 +159,7 @@ func (r *UpgradePlanReconciler) upgradeHelmChart(ctx context.Context, upgradePla
 
 	job := &batchv1.Job{}
 	if err = r.Get(ctx, types.NamespacedName{Name: chart.Status.JobName, Namespace: upgrade.ChartNamespace}, job); err != nil {
-		return upgrade.ChartStateUnknown, err
+		return upgrade.ChartStateUnknown, client.IgnoreNotFound(err)
 	}
 
 	idx := slices.IndexFunc(job.Status.Conditions, func(condition batchv1.JobCondition) bool {

--- a/internal/controller/helm.go
+++ b/internal/controller/helm.go
@@ -104,7 +104,7 @@ func (r *UpgradePlanReconciler) createHelmChart(ctx context.Context, upgradePlan
 			APIVersion: "helm.cattle.io/v1",
 		},
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      releaseChart.Name,
+			Name:      installedChart.Name,
 			Namespace: upgrade.ChartNamespace,
 			Annotations: map[string]string{
 				upgrade.PlanAnnotation:    upgradePlan.Name,

--- a/internal/controller/reconcile_metallb.go
+++ b/internal/controller/reconcile_metallb.go
@@ -1,0 +1,22 @@
+package controller
+
+import (
+	"context"
+
+	lifecyclev1alpha1 "github.com/suse-edge/upgrade-controller/api/v1alpha1"
+	"github.com/suse-edge/upgrade-controller/pkg/release"
+
+	ctrl "sigs.k8s.io/controller-runtime"
+)
+
+func (r *UpgradePlanReconciler) reconcileMetalLB(ctx context.Context, upgradePlan *lifecyclev1alpha1.UpgradePlan, metallb *release.HelmChart) (ctrl.Result, error) {
+	state, err := r.upgradeHelmChart(ctx, upgradePlan, metallb)
+	if err != nil {
+		return ctrl.Result{}, err
+	}
+
+	setCondition, requeue := evaluateHelmChartState(state)
+	setCondition(upgradePlan, lifecyclev1alpha1.MetalLBUpgradedCondition, state.Message())
+
+	return ctrl.Result{Requeue: requeue}, nil
+}

--- a/internal/controller/upgradeplan_controller.go
+++ b/internal/controller/upgradeplan_controller.go
@@ -94,6 +94,7 @@ func (r *UpgradePlanReconciler) executePlan(ctx context.Context, upgradePlan *li
 		setPendingCondition(upgradePlan, lifecyclev1alpha1.KubernetesUpgradedCondition, "Kubernetes upgrade is not yet started")
 		setPendingCondition(upgradePlan, lifecyclev1alpha1.RancherUpgradedCondition, "Rancher upgrade is not yet started")
 		setPendingCondition(upgradePlan, lifecyclev1alpha1.LonghornUpgradedCondition, "Longhorn upgrade is not yet started")
+		setPendingCondition(upgradePlan, lifecyclev1alpha1.MetalLBUpgradedCondition, "MetalLB upgrade is not yet started")
 
 		return ctrl.Result{Requeue: true}, nil
 	}
@@ -107,6 +108,8 @@ func (r *UpgradePlanReconciler) executePlan(ctx context.Context, upgradePlan *li
 		return r.reconcileRancher(ctx, upgradePlan, &release.Components.Rancher)
 	case !isHelmUpgradeFinished(upgradePlan, lifecyclev1alpha1.LonghornUpgradedCondition):
 		return r.reconcileLonghorn(ctx, upgradePlan, &release.Components.Longhorn)
+	case !isHelmUpgradeFinished(upgradePlan, lifecyclev1alpha1.MetalLBUpgradedCondition):
+		return r.reconcileMetalLB(ctx, upgradePlan, &release.Components.MetalLB)
 	}
 
 	logger := log.FromContext(ctx)

--- a/manifests/release-3.0.1.yaml
+++ b/manifests/release-3.0.1.yaml
@@ -7,11 +7,13 @@ components:
     rke2:
       version: v1.28.9+rke2r1
   rancher:
+    releaseName: rancher
     chart: rancher
     version: v2.8.5
     repository: https://charts.rancher.com/server-charts/prime
     namespace: cattle-system
   longhorn:
+    releaseName: longhorn
     chart: longhorn
     version: v1.6.1
     repository: https://charts.longhorn.io

--- a/manifests/release-3.0.1.yaml
+++ b/manifests/release-3.0.1.yaml
@@ -16,6 +16,10 @@ components:
     version: v1.6.1
     repository: https://charts.longhorn.io
     namespace: longhorn-system
+  metallb:
+    chart: oci://registry.suse.com/edge/metallb-chart
+    version: 0.14.3
+    namespace: metallb-system
   operatingSystem:
     version: 6.0
     zypperID: SL-Micro

--- a/manifests/release-3.0.1.yaml
+++ b/manifests/release-3.0.1.yaml
@@ -17,6 +17,7 @@ components:
     repository: https://charts.longhorn.io
     namespace: longhorn-system
   metallb:
+    releaseName: metallb
     chart: oci://registry.suse.com/edge/metallb-chart
     version: 0.14.3
     namespace: metallb-system

--- a/pkg/release/release.go
+++ b/pkg/release/release.go
@@ -11,6 +11,7 @@ type Components struct {
 	OperatingSystem OperatingSystem `yaml:"operatingSystem"`
 	Rancher         HelmChart       `yaml:"rancher"`
 	Longhorn        HelmChart       `yaml:"longhorn"`
+	MetalLB         HelmChart       `yaml:"metallb"`
 }
 
 type Kubernetes struct {

--- a/pkg/release/release.go
+++ b/pkg/release/release.go
@@ -33,8 +33,9 @@ type OperatingSystem struct {
 }
 
 type HelmChart struct {
-	Name       string `yaml:"chart"`
-	Repository string `yaml:"repository"`
-	Version    string `yaml:"version"`
-	Namespace  string `yaml:"namespace"`
+	ReleaseName string `yaml:"releaseName"`
+	Name        string `yaml:"chart"`
+	Repository  string `yaml:"repository"`
+	Version     string `yaml:"version"`
+	Namespace   string `yaml:"namespace"`
 }


### PR DESCRIPTION
Introduces upgrades for the `MetalLB` helm chart.

**_Notes:_**
Due to the fact that MetalLB is the first SUSE Edge team supported helm chart that is being included in the `upgrade-controller` some changes needed to be made to the existing chart upgrade implementation. Changes include:
1. A new property was added to the `Release Manifest` called `releaseName`. Its idea is to represent the name of the Helm release that we need to search for. This was needed, mainly because for OCI-based Helm charts we need to provide the full chart URL under the `<component>.chart` property. We previously used this property to find the release related to the specific chart. The suggested logic checks whether `releaseName` exists, if it exists this is the property that is used in the `retrieveHelmRelease()` function, if it is missing, we use the `chart` property.
2. Had to change the name of the `HelmChart` resource that we create when a Helm release is present, but no `HelmChart` exists. Again needed mainly due to the same reasons from (1). Now we use the name of the existing Helm release for the `HelmChart` resource.