### PR TITLE
Remove unused namespace property

### DIFF
--- a/manifests/release-3.0.1.yaml
+++ b/manifests/release-3.0.1.yaml
@@ -11,18 +11,15 @@ components:
     chart: rancher
     version: v2.8.5
     repository: https://charts.rancher.com/server-charts/prime
-    namespace: cattle-system
   longhorn:
     releaseName: longhorn
     chart: longhorn
     version: v1.6.1
     repository: https://charts.longhorn.io
-    namespace: longhorn-system
   metallb:
     releaseName: metallb
     chart: oci://registry.suse.com/edge/metallb-chart
     version: 0.14.3
-    namespace: metallb-system
   operatingSystem:
     version: 6.0
     zypperID: SL-Micro

--- a/pkg/release/release.go
+++ b/pkg/release/release.go
@@ -37,5 +37,4 @@ type HelmChart struct {
 	Name        string `yaml:"chart"`
 	Repository  string `yaml:"repository"`
 	Version     string `yaml:"version"`
-	Namespace   string `yaml:"namespace"`
 }


### PR DESCRIPTION
The `namespace` property from the release manifest is no longer used by the controller, so we can remove it.