### PR TITLE
Kubevirt chart upgrade

### DIFF
--- a/api/v1alpha1/upgradeplan_types.go
+++ b/api/v1alpha1/upgradeplan_types.go
@@ -28,7 +28,7 @@ const (
 	LonghornUpgradedCondition   = "LonghornUpgraded"
 	MetalLBUpgradedCondition    = "MetalLBUpgraded"
 	CDIUpgradedCondition        = "CDIUpgraded"
-	KubevirtUpgradedCondition   = "KubevirtUpgraded"
+	KubevirtUpgradedCondition   = "KubeVirtUpgraded"
 
 	// UpgradeError indicates that the upgrade process has encountered a transient error.
 	UpgradeError = "Error"

--- a/api/v1alpha1/upgradeplan_types.go
+++ b/api/v1alpha1/upgradeplan_types.go
@@ -28,6 +28,7 @@ const (
 	LonghornUpgradedCondition   = "LonghornUpgraded"
 	MetalLBUpgradedCondition    = "MetalLBUpgraded"
 	CDIUpgradedCondition        = "CDIUpgraded"
+	KubevirtUpgradedCondition   = "KubevirtUpgraded"
 
 	// UpgradeError indicates that the upgrade process has encountered a transient error.
 	UpgradeError = "Error"

--- a/internal/controller/reconcile_kubevirt.go
+++ b/internal/controller/reconcile_kubevirt.go
@@ -1,0 +1,22 @@
+package controller
+
+import (
+	"context"
+
+	lifecyclev1alpha1 "github.com/suse-edge/upgrade-controller/api/v1alpha1"
+	"github.com/suse-edge/upgrade-controller/pkg/release"
+
+	ctrl "sigs.k8s.io/controller-runtime"
+)
+
+func (r *UpgradePlanReconciler) reconcileKubevirt(ctx context.Context, upgradePlan *lifecyclev1alpha1.UpgradePlan, kubevirt *release.HelmChart) (ctrl.Result, error) {
+	state, err := r.upgradeHelmChart(ctx, upgradePlan, kubevirt)
+	if err != nil {
+		return ctrl.Result{}, err
+	}
+
+	setCondition, requeue := evaluateHelmChartState(state)
+	setCondition(upgradePlan, lifecyclev1alpha1.KubevirtUpgradedCondition, state.Message())
+
+	return ctrl.Result{Requeue: requeue}, nil
+}

--- a/internal/controller/upgradeplan_controller.go
+++ b/internal/controller/upgradeplan_controller.go
@@ -96,6 +96,7 @@ func (r *UpgradePlanReconciler) executePlan(ctx context.Context, upgradePlan *li
 		setPendingCondition(upgradePlan, lifecyclev1alpha1.LonghornUpgradedCondition, "Longhorn upgrade is not yet started")
 		setPendingCondition(upgradePlan, lifecyclev1alpha1.MetalLBUpgradedCondition, "MetalLB upgrade is not yet started")
 		setPendingCondition(upgradePlan, lifecyclev1alpha1.CDIUpgradedCondition, "CDI upgrade is not yet started")
+		setPendingCondition(upgradePlan, lifecyclev1alpha1.KubevirtUpgradedCondition, "Kubevirt upgrade is not yet started")
 
 		return ctrl.Result{Requeue: true}, nil
 	}
@@ -113,6 +114,8 @@ func (r *UpgradePlanReconciler) executePlan(ctx context.Context, upgradePlan *li
 		return r.reconcileMetalLB(ctx, upgradePlan, &release.Components.MetalLB)
 	case !isHelmUpgradeFinished(upgradePlan, lifecyclev1alpha1.CDIUpgradedCondition):
 		return r.reconcileCDI(ctx, upgradePlan, &release.Components.CDI)
+	case !isHelmUpgradeFinished(upgradePlan, lifecyclev1alpha1.KubevirtUpgradedCondition):
+		return r.reconcileKubevirt(ctx, upgradePlan, &release.Components.KubeVirt)
 	}
 
 	logger := log.FromContext(ctx)

--- a/internal/controller/upgradeplan_controller.go
+++ b/internal/controller/upgradeplan_controller.go
@@ -96,7 +96,7 @@ func (r *UpgradePlanReconciler) executePlan(ctx context.Context, upgradePlan *li
 		setPendingCondition(upgradePlan, lifecyclev1alpha1.LonghornUpgradedCondition, "Longhorn upgrade is not yet started")
 		setPendingCondition(upgradePlan, lifecyclev1alpha1.MetalLBUpgradedCondition, "MetalLB upgrade is not yet started")
 		setPendingCondition(upgradePlan, lifecyclev1alpha1.CDIUpgradedCondition, "CDI upgrade is not yet started")
-		setPendingCondition(upgradePlan, lifecyclev1alpha1.KubevirtUpgradedCondition, "Kubevirt upgrade is not yet started")
+		setPendingCondition(upgradePlan, lifecyclev1alpha1.KubevirtUpgradedCondition, "KubeVirt upgrade is not yet started")
 
 		return ctrl.Result{Requeue: true}, nil
 	}

--- a/manifests/release-3.0.1.yaml
+++ b/manifests/release-3.0.1.yaml
@@ -24,6 +24,10 @@ components:
     releaseName: cdi
     chart: oci://registry.suse.com/edge/cdi-chart
     version: 0.2.3
+  kubevirt:
+    releaseName: kubevirt
+    chart: oci://registry.suse.com/edge/kubevirt-chart
+    version: 0.2.4
   operatingSystem:
     version: 6.0
     zypperID: SL-Micro

--- a/pkg/release/release.go
+++ b/pkg/release/release.go
@@ -13,6 +13,7 @@ type Components struct {
 	Longhorn        HelmChart       `yaml:"longhorn"`
 	MetalLB         HelmChart       `yaml:"metallb"`
 	CDI             HelmChart       `yaml:"cdi"`
+	KubeVirt        HelmChart       `yaml:"kubevirt"`
 }
 
 type Kubernetes struct {


### PR DESCRIPTION
Kubevirt chart upgrade implementation.

Note:
- In order to prevent unwanted errors, the `0.2.4` version is used in the release manifest, because `0.3.0` is not yet present in `registry.suse.com/edge/kubevirt-chart`.