### PR TITLE
Upgrade NeuVector

### DIFF
--- a/api/v1alpha1/upgradeplan_types.go
+++ b/api/v1alpha1/upgradeplan_types.go
@@ -29,6 +29,7 @@ const (
 	MetalLBUpgradedCondition    = "MetalLBUpgraded"
 	CDIUpgradedCondition        = "CDIUpgraded"
 	KubevirtUpgradedCondition   = "KubeVirtUpgraded"
+	NeuVectorUpgradedCondition  = "NeuVectorUpgraded"
 
 	// UpgradeError indicates that the upgrade process has encountered a transient error.
 	UpgradeError = "Error"

--- a/internal/controller/helm.go
+++ b/internal/controller/helm.go
@@ -200,3 +200,7 @@ func evaluateHelmChartState(state upgrade.HelmChartState) (setCondition setCondi
 		return setErrorCondition, false
 	}
 }
+
+func dependentHelmChartMissingMessage(dependency, dependent string) string {
+	return fmt.Sprintf("Chart %s was successfully upgraded but chart %s is not installed", dependency, dependent)
+}

--- a/internal/controller/helm.go
+++ b/internal/controller/helm.go
@@ -202,5 +202,5 @@ func evaluateHelmChartState(state upgrade.HelmChartState) (setCondition setCondi
 }
 
 func dependentHelmChartMissingMessage(dependency, dependent string) string {
-	return fmt.Sprintf("Chart %s was successfully upgraded but chart %s is not installed", dependency, dependent)
+	return fmt.Sprintf("Chart %s is installed but chart %s is not", dependency, dependent)
 }

--- a/internal/controller/reconcile_neuvector.go
+++ b/internal/controller/reconcile_neuvector.go
@@ -17,7 +17,7 @@ func (r *UpgradePlanReconciler) reconcileNeuVector(ctx context.Context, upgradeP
 
 	conditionType := lifecyclev1alpha1.NeuVectorUpgradedCondition
 
-	if state != upgrade.ChartStateSucceeded {
+	if state != upgrade.ChartStateSucceeded && state != upgrade.ChartStateVersionAlreadyInstalled {
 		setCondition, requeue := evaluateHelmChartState(state)
 		setCondition(upgradePlan, conditionType, state.FormattedMessage(neuVector.CRD.ReleaseName))
 

--- a/internal/controller/reconcile_neuvector.go
+++ b/internal/controller/reconcile_neuvector.go
@@ -1,0 +1,41 @@
+package controller
+
+import (
+	"context"
+
+	lifecyclev1alpha1 "github.com/suse-edge/upgrade-controller/api/v1alpha1"
+	"github.com/suse-edge/upgrade-controller/internal/upgrade"
+	"github.com/suse-edge/upgrade-controller/pkg/release"
+	ctrl "sigs.k8s.io/controller-runtime"
+)
+
+func (r *UpgradePlanReconciler) reconcileNeuVector(ctx context.Context, upgradePlan *lifecyclev1alpha1.UpgradePlan, neuVector *release.NeuVector) (ctrl.Result, error) {
+	state, err := r.upgradeHelmChart(ctx, upgradePlan, &neuVector.CRD)
+	if err != nil {
+		return ctrl.Result{}, err
+	}
+
+	conditionType := lifecyclev1alpha1.NeuVectorUpgradedCondition
+
+	if state != upgrade.ChartStateSucceeded {
+		setCondition, requeue := evaluateHelmChartState(state)
+		setCondition(upgradePlan, conditionType, state.FormattedMessage(neuVector.CRD.ReleaseName))
+
+		return ctrl.Result{Requeue: requeue}, err
+	}
+
+	state, err = r.upgradeHelmChart(ctx, upgradePlan, &neuVector.NeuVector)
+	if err != nil {
+		return ctrl.Result{}, err
+	}
+
+	if state == upgrade.ChartStateNotInstalled {
+		setFailedCondition(upgradePlan, conditionType, dependentHelmChartMissingMessage(neuVector.CRD.ReleaseName, neuVector.NeuVector.ReleaseName))
+		return ctrl.Result{Requeue: true}, nil
+	}
+
+	setCondition, requeue := evaluateHelmChartState(state)
+	setCondition(upgradePlan, conditionType, state.FormattedMessage(neuVector.NeuVector.ReleaseName))
+
+	return ctrl.Result{Requeue: requeue}, err
+}

--- a/internal/controller/upgradeplan_controller.go
+++ b/internal/controller/upgradeplan_controller.go
@@ -97,6 +97,7 @@ func (r *UpgradePlanReconciler) executePlan(ctx context.Context, upgradePlan *li
 		setPendingCondition(upgradePlan, lifecyclev1alpha1.MetalLBUpgradedCondition, "MetalLB upgrade is not yet started")
 		setPendingCondition(upgradePlan, lifecyclev1alpha1.CDIUpgradedCondition, "CDI upgrade is not yet started")
 		setPendingCondition(upgradePlan, lifecyclev1alpha1.KubevirtUpgradedCondition, "KubeVirt upgrade is not yet started")
+		setPendingCondition(upgradePlan, lifecyclev1alpha1.NeuVectorUpgradedCondition, "NeuVector upgrade is not yet started")
 
 		return ctrl.Result{Requeue: true}, nil
 	}
@@ -116,6 +117,8 @@ func (r *UpgradePlanReconciler) executePlan(ctx context.Context, upgradePlan *li
 		return r.reconcileCDI(ctx, upgradePlan, &release.Components.CDI)
 	case !isHelmUpgradeFinished(upgradePlan, lifecyclev1alpha1.KubevirtUpgradedCondition):
 		return r.reconcileKubevirt(ctx, upgradePlan, &release.Components.KubeVirt)
+	case !isHelmUpgradeFinished(upgradePlan, lifecyclev1alpha1.NeuVectorUpgradedCondition):
+		return r.reconcileNeuVector(ctx, upgradePlan, &release.Components.NeuVector)
 	}
 
 	logger := log.FromContext(ctx)

--- a/internal/upgrade/helm.go
+++ b/internal/upgrade/helm.go
@@ -1,6 +1,10 @@
 package upgrade
 
-import "k8s.io/apimachinery/pkg/types"
+import (
+	"fmt"
+
+	"k8s.io/apimachinery/pkg/types"
+)
 
 const (
 	ChartNamespace = "kube-system"
@@ -38,6 +42,25 @@ func (s HelmChartState) Message() string {
 		return "Chart upgrade failed"
 	case ChartStateSucceeded:
 		return "Chart upgrade succeeded"
+	default:
+		return ""
+	}
+}
+
+func (s HelmChartState) FormattedMessage(chart string) string {
+	switch s {
+	case ChartStateUnknown:
+		return fmt.Sprintf("State of chart %s is unknown", chart)
+	case ChartStateNotInstalled:
+		return fmt.Sprintf("Chart %s is not installed", chart)
+	case ChartStateVersionAlreadyInstalled:
+		return fmt.Sprintf("Specified version of chart %s is already installed", chart)
+	case ChartStateInProgress:
+		return fmt.Sprintf("Chart %s upgrade is in progress", chart)
+	case ChartStateFailed:
+		return fmt.Sprintf("Chart %s upgrade failed", chart)
+	case ChartStateSucceeded:
+		return fmt.Sprintf("Chart %s upgrade succeeded", chart)
 	default:
 		return ""
 	}

--- a/manifests/release-3.0.1.yaml
+++ b/manifests/release-3.0.1.yaml
@@ -28,6 +28,17 @@ components:
     releaseName: kubevirt
     chart: oci://registry.suse.com/edge/kubevirt-chart
     version: 0.2.4
+  neuvector:
+    crd:
+      releaseName: neuvector-crd
+      chart: neuvector-crd
+      version: 103.0.4+up2.7.7
+      repository: https://charts.rancher.io
+    neuvector:
+      releaseName: neuvector
+      chart: neuvector
+      version: 103.0.4+up2.7.7
+      repository: https://charts.rancher.io
   operatingSystem:
     version: 6.0
     zypperID: SL-Micro

--- a/pkg/release/release.go
+++ b/pkg/release/release.go
@@ -14,6 +14,7 @@ type Components struct {
 	MetalLB         HelmChart       `yaml:"metallb"`
 	CDI             HelmChart       `yaml:"cdi"`
 	KubeVirt        HelmChart       `yaml:"kubevirt"`
+	NeuVector       NeuVector       `yaml:"neuvector"`
 }
 
 type Kubernetes struct {
@@ -39,4 +40,9 @@ type HelmChart struct {
 	Name        string `yaml:"chart"`
 	Repository  string `yaml:"repository"`
 	Version     string `yaml:"version"`
+}
+
+type NeuVector struct {
+	CRD       HelmChart `yaml:"crd"`
+	NeuVector HelmChart `yaml:"neuvector"`
 }


### PR DESCRIPTION
- Introduces NeuVector component upgrade
- NeuVector is a component consisting of two different Helm charts (CRDs being extracted in a separate one)
  - The upgrade procedure relies on upgrading the CRD chart first and then proceeding with the main one
  - Discrepancies between the charts is handled where we:
    - Consider the upgrade failed if the CRD is upgraded but the main chart does not exist
    - Allow for main chart upgrades even if the CRD version is already installed on the cluster
