### PR TITLE
Drop message func in favour of using formatted message

### DIFF
--- a/internal/controller/reconcile_cdi.go
+++ b/internal/controller/reconcile_cdi.go
@@ -15,7 +15,7 @@ func (r *UpgradePlanReconciler) reconcileCDI(ctx context.Context, upgradePlan *l
 	}
 
 	setCondition, requeue := evaluateHelmChartState(state)
-	setCondition(upgradePlan, lifecyclev1alpha1.CDIUpgradedCondition, state.Message())
+	setCondition(upgradePlan, lifecyclev1alpha1.CDIUpgradedCondition, state.FormattedMessage(cdi.ReleaseName))
 
 	return ctrl.Result{Requeue: requeue}, nil
 }

--- a/internal/controller/reconcile_kubevirt.go
+++ b/internal/controller/reconcile_kubevirt.go
@@ -16,7 +16,7 @@ func (r *UpgradePlanReconciler) reconcileKubevirt(ctx context.Context, upgradePl
 	}
 
 	setCondition, requeue := evaluateHelmChartState(state)
-	setCondition(upgradePlan, lifecyclev1alpha1.KubevirtUpgradedCondition, state.Message())
+	setCondition(upgradePlan, lifecyclev1alpha1.KubevirtUpgradedCondition, state.FormattedMessage(kubevirt.ReleaseName))
 
 	return ctrl.Result{Requeue: requeue}, nil
 }

--- a/internal/controller/reconcile_longhorn.go
+++ b/internal/controller/reconcile_longhorn.go
@@ -15,7 +15,7 @@ func (r *UpgradePlanReconciler) reconcileLonghorn(ctx context.Context, upgradePl
 	}
 
 	setCondition, requeue := evaluateHelmChartState(state)
-	setCondition(upgradePlan, lifecyclev1alpha1.LonghornUpgradedCondition, state.Message())
+	setCondition(upgradePlan, lifecyclev1alpha1.LonghornUpgradedCondition, state.FormattedMessage(longhorn.ReleaseName))
 
 	return ctrl.Result{Requeue: requeue}, nil
 }

--- a/internal/controller/reconcile_metallb.go
+++ b/internal/controller/reconcile_metallb.go
@@ -16,7 +16,7 @@ func (r *UpgradePlanReconciler) reconcileMetalLB(ctx context.Context, upgradePla
 	}
 
 	setCondition, requeue := evaluateHelmChartState(state)
-	setCondition(upgradePlan, lifecyclev1alpha1.MetalLBUpgradedCondition, state.Message())
+	setCondition(upgradePlan, lifecyclev1alpha1.MetalLBUpgradedCondition, state.FormattedMessage(metallb.ReleaseName))
 
 	return ctrl.Result{Requeue: requeue}, nil
 }

--- a/internal/controller/reconcile_rancher.go
+++ b/internal/controller/reconcile_rancher.go
@@ -15,7 +15,7 @@ func (r *UpgradePlanReconciler) reconcileRancher(ctx context.Context, upgradePla
 	}
 
 	setCondition, requeue := evaluateHelmChartState(state)
-	setCondition(upgradePlan, lifecyclev1alpha1.RancherUpgradedCondition, state.Message())
+	setCondition(upgradePlan, lifecyclev1alpha1.RancherUpgradedCondition, state.FormattedMessage(rancher.ReleaseName))
 
 	return ctrl.Result{Requeue: requeue}, nil
 }

--- a/internal/upgrade/helm.go
+++ b/internal/upgrade/helm.go
@@ -28,25 +28,6 @@ const (
 	ChartStateSucceeded
 )
 
-func (s HelmChartState) Message() string {
-	switch s {
-	case ChartStateUnknown:
-		return "Chart state is unknown"
-	case ChartStateNotInstalled:
-		return "Chart is not installed"
-	case ChartStateVersionAlreadyInstalled:
-		return "Chart version is already installed"
-	case ChartStateInProgress:
-		return "Chart upgrade is in progress"
-	case ChartStateFailed:
-		return "Chart upgrade failed"
-	case ChartStateSucceeded:
-		return "Chart upgrade succeeded"
-	default:
-		return ""
-	}
-}
-
 func (s HelmChartState) FormattedMessage(chart string) string {
 	switch s {
 	case ChartStateUnknown:


### PR DESCRIPTION
Drop the `Message()` helm state function in favour of the more informative `FormattedMessage()` function.