### PR TITLE
Kubevirt dashboard upgrade

### DIFF
--- a/internal/controller/reconcile_kubevirt.go
+++ b/internal/controller/reconcile_kubevirt.go
@@ -4,19 +4,33 @@ import (
 	"context"
 
 	lifecyclev1alpha1 "github.com/suse-edge/upgrade-controller/api/v1alpha1"
+	"github.com/suse-edge/upgrade-controller/internal/upgrade"
 	"github.com/suse-edge/upgrade-controller/pkg/release"
 
 	ctrl "sigs.k8s.io/controller-runtime"
 )
 
-func (r *UpgradePlanReconciler) reconcileKubevirt(ctx context.Context, upgradePlan *lifecyclev1alpha1.UpgradePlan, kubevirt *release.HelmChart) (ctrl.Result, error) {
-	state, err := r.upgradeHelmChart(ctx, upgradePlan, kubevirt)
+func (r *UpgradePlanReconciler) reconcileKubevirt(ctx context.Context, upgradePlan *lifecyclev1alpha1.UpgradePlan, kubevirt *release.KubeVirt) (ctrl.Result, error) {
+	state, err := r.upgradeHelmChart(ctx, upgradePlan, &kubevirt.KubeVirt)
+	if err != nil {
+		return ctrl.Result{}, err
+	}
+
+	conditionType := lifecyclev1alpha1.KubevirtUpgradedCondition
+	if state != upgrade.ChartStateSucceeded && state != upgrade.ChartStateVersionAlreadyInstalled {
+		setCondition, requeue := evaluateHelmChartState(state)
+		setCondition(upgradePlan, conditionType, state.FormattedMessage(kubevirt.KubeVirt.ReleaseName))
+
+		return ctrl.Result{Requeue: requeue}, err
+	}
+
+	state, err = r.upgradeHelmChart(ctx, upgradePlan, &kubevirt.DashboardExtension)
 	if err != nil {
 		return ctrl.Result{}, err
 	}
 
 	setCondition, requeue := evaluateHelmChartState(state)
-	setCondition(upgradePlan, lifecyclev1alpha1.KubevirtUpgradedCondition, state.FormattedMessage(kubevirt.ReleaseName))
+	setCondition(upgradePlan, conditionType, state.FormattedMessage(kubevirt.DashboardExtension.ReleaseName))
 
-	return ctrl.Result{Requeue: requeue}, nil
+	return ctrl.Result{Requeue: requeue}, err
 }

--- a/internal/controller/upgradeplan_controller.go
+++ b/internal/controller/upgradeplan_controller.go
@@ -141,7 +141,7 @@ func (r *UpgradePlanReconciler) createSecret(ctx context.Context, upgradePlan *l
 		return fmt.Errorf("creating secret: %w", err)
 	}
 
-	r.recordCreatedObject(upgradePlan, "SecretCreated", fmt.Sprintf("Secret created: %s/%s", secret.Namespace, secret.Name))
+	r.recordPlanEvent(upgradePlan, corev1.EventTypeNormal, "SecretCreated", fmt.Sprintf("Secret created: %s/%s", secret.Namespace, secret.Name))
 	return nil
 }
 
@@ -150,7 +150,7 @@ func (r *UpgradePlanReconciler) createPlan(ctx context.Context, upgradePlan *lif
 		return fmt.Errorf("creating upgrade plan: %w", err)
 	}
 
-	r.recordCreatedObject(upgradePlan, "PlanCreated", fmt.Sprintf("Upgrade plan created: %s/%s", plan.Namespace, plan.Name))
+	r.recordPlanEvent(upgradePlan, corev1.EventTypeNormal, "PlanCreated", fmt.Sprintf("Upgrade plan created: %s/%s", plan.Namespace, plan.Name))
 	return nil
 }
 
@@ -166,8 +166,8 @@ func (r *UpgradePlanReconciler) createObject(ctx context.Context, upgradePlan *l
 	return nil
 }
 
-func (r *UpgradePlanReconciler) recordCreatedObject(upgradePlan *lifecyclev1alpha1.UpgradePlan, reason, msg string) {
-	r.Recorder.Eventf(upgradePlan, corev1.EventTypeNormal, reason, msg)
+func (r *UpgradePlanReconciler) recordPlanEvent(upgradePlan *lifecyclev1alpha1.UpgradePlan, eventType, reason, msg string) {
+	r.Recorder.Eventf(upgradePlan, eventType, reason, msg)
 }
 
 func isHelmUpgradeFinished(plan *lifecyclev1alpha1.UpgradePlan, conditionType string) bool {

--- a/manifests/release-3.0.1.yaml
+++ b/manifests/release-3.0.1.yaml
@@ -25,9 +25,14 @@ components:
     chart: oci://registry.suse.com/edge/cdi-chart
     version: 0.2.3
   kubevirt:
-    releaseName: kubevirt
-    chart: oci://registry.suse.com/edge/kubevirt-chart
-    version: 0.2.4
+    kubevirt:
+      releaseName: kubevirt
+      chart: oci://registry.suse.com/edge/kubevirt-chart
+      version: 0.2.4
+    dashboardExtension:
+      releaseName: kubevirt-dashboard-extension
+      chart: oci://registry.suse.com/edge/kubevirt-dashboard-extension-chart
+      version: 1.0.0
   neuvector:
     crd:
       releaseName: neuvector-crd

--- a/pkg/release/release.go
+++ b/pkg/release/release.go
@@ -13,7 +13,7 @@ type Components struct {
 	Longhorn               HelmChart       `yaml:"longhorn"`
 	MetalLB                HelmChart       `yaml:"metallb"`
 	CDI                    HelmChart       `yaml:"cdi"`
-	KubeVirt               HelmChart       `yaml:"kubevirt"`
+	KubeVirt               KubeVirt        `yaml:"kubevirt"`
 	NeuVector              NeuVector       `yaml:"neuvector"`
 	EndpointCopierOperator HelmChart       `yaml:"endpointCopierOperator"`
 	Elemental              Elemental       `yaml:"elemental"`
@@ -58,4 +58,9 @@ type Elemental struct {
 type SRIOV struct {
 	CRD             HelmChart `yaml:"crd"`
 	NetworkOperator HelmChart `yaml:"networkOperator"`
+}
+
+type KubeVirt struct {
+	KubeVirt           HelmChart `yaml:"kubevirt"`
+	DashboardExtension HelmChart `yaml:"dashboardExtension"`
 }


### PR DESCRIPTION
Kubevirt dashboard upgrade implementation.

Upgrade is done as part of the Kubevirt upgrade, where:
- If Kubevirt is missing, the dashboard is not upgraded
- If Kubevirt upgrade fails, the dashboard is not upgraded

In order to not produce misleading conditions, the following flow is followed:
- If dashboard upgrade fails we count the KubeVirt upgrade as succeeded and we add a warning event to the UpgradePlan - reasoning here is mainly that KubeVirt is the main upgrade component and the condition is counted as succeeded when KubeVirt is upgraded. Add-on component failures are added as warnings.
- If the dashboard upgrade is missing, or it is not eligible for upgrade (the chart is with the same version as the one specified in the release manifest), then the condition for the KubeVirt chart is used - This is done in order to not display misleading "Skipped" conditions for the KubeVirt component, when the dashboards are missing/not eligible for upgrade.

Screenshot for when we have KubeVirt, but the dashboard upgrade failed:
![Screenshot 2024-08-07 at 15 29 45](https://github.com/user-attachments/assets/fef1af07-fed3-42d1-aa6e-9e640cb0dd33)

Screenshot for when the KubeVirt and dashboard upgrades succeeded:
![Screenshot 2024-08-07 at 16 04 14](https://github.com/user-attachments/assets/c5ba5177-e743-4d32-a0e1-806b283b1ee4)

Screenshot for when KubeVirt is upgraded and the dashboard is missing:
![Screenshot 2024-08-07 at 16 05 29](https://github.com/user-attachments/assets/a4afdfb4-7397-48c8-b62c-0baedb17965a)

Screenshot when Kubevirt is not installed and the dashboard is there/missing (it is the same output):
![Screenshot 2024-08-07 at 16 08 21](https://github.com/user-attachments/assets/f78abc8c-9537-4945-bc06-59b5dfe0ef57)

