### PR TITLE
Akri dashboard upgrade

### DIFF
--- a/internal/controller/reconcile_akri.go
+++ b/internal/controller/reconcile_akri.go
@@ -2,20 +2,47 @@ package controller
 
 import (
 	"context"
+	"fmt"
 
 	lifecyclev1alpha1 "github.com/suse-edge/upgrade-controller/api/v1alpha1"
+	"github.com/suse-edge/upgrade-controller/internal/upgrade"
 	"github.com/suse-edge/upgrade-controller/pkg/release"
+	corev1 "k8s.io/api/core/v1"
 	ctrl "sigs.k8s.io/controller-runtime"
 )
 
-func (r *UpgradePlanReconciler) reconcileAkri(ctx context.Context, upgradePlan *lifecyclev1alpha1.UpgradePlan, akri *release.HelmChart) (ctrl.Result, error) {
-	state, err := r.upgradeHelmChart(ctx, upgradePlan, akri)
+func (r *UpgradePlanReconciler) reconcileAkri(ctx context.Context, upgradePlan *lifecyclev1alpha1.UpgradePlan, akri *release.Akri) (ctrl.Result, error) {
+	akriState, err := r.upgradeHelmChart(ctx, upgradePlan, &akri.Akri)
 	if err != nil {
 		return ctrl.Result{}, err
 	}
 
-	setCondition, requeue := evaluateHelmChartState(state)
-	setCondition(upgradePlan, lifecyclev1alpha1.AkriUpgradedCondition, state.FormattedMessage(akri.ReleaseName))
+	conditionType := lifecyclev1alpha1.AkriUpgradedCondition
+	if akriState != upgrade.ChartStateSucceeded && akriState != upgrade.ChartStateVersionAlreadyInstalled {
+		setCondition, requeue := evaluateHelmChartState(akriState)
+		setCondition(upgradePlan, conditionType, akriState.FormattedMessage(akri.Akri.ReleaseName))
 
-	return ctrl.Result{Requeue: requeue}, nil
+		return ctrl.Result{Requeue: requeue}, err
+	}
+
+	dashboardState, err := r.upgradeHelmChart(ctx, upgradePlan, &akri.DashboardExtension)
+	if err != nil {
+		return ctrl.Result{}, err
+	}
+
+	switch dashboardState {
+	case upgrade.ChartStateFailed:
+		msg := fmt.Sprintf("Main component '%s' upgraded successfully, but add-on component '%s' failed to upgrade", akri.Akri.ReleaseName, akri.DashboardExtension.ReleaseName)
+		r.recordPlanEvent(upgradePlan, corev1.EventTypeWarning, conditionType, msg)
+
+		fallthrough
+	case upgrade.ChartStateNotInstalled, upgrade.ChartStateVersionAlreadyInstalled:
+		setCondition, requeue := evaluateHelmChartState(akriState)
+		setCondition(upgradePlan, conditionType, akriState.FormattedMessage(akri.Akri.ReleaseName))
+		return ctrl.Result{Requeue: requeue}, nil
+	default:
+		setCondition, requeue := evaluateHelmChartState(dashboardState)
+		setCondition(upgradePlan, conditionType, dashboardState.FormattedMessage(akri.DashboardExtension.ReleaseName))
+		return ctrl.Result{Requeue: requeue}, nil
+	}
 }

--- a/manifests/release-3.0.1.yaml
+++ b/manifests/release-3.0.1.yaml
@@ -67,9 +67,14 @@ components:
       chart: oci://registry.suse.com/edge/sriov-network-operator-chart
       version: 1.2.2
   akri:
-    releaseName: akri
-    chart: oci://registry.suse.com/edge/akri-chart
-    version: 0.12.20
+    akri:
+      releaseName: akri
+      chart: oci://registry.suse.com/edge/akri-chart
+      version: 0.12.20
+    dashboardExtension:
+      releaseName: akri-dashboard-extension
+      chart: oci://registry.suse.com/edge/akri-dashboard-extension-chart
+      version: 1.0.0
   metal3:
     releaseName: metal3
     chart: oci://registry.suse.com/edge/metal3-chart

--- a/pkg/release/release.go
+++ b/pkg/release/release.go
@@ -18,7 +18,7 @@ type Components struct {
 	EndpointCopierOperator HelmChart       `yaml:"endpointCopierOperator"`
 	Elemental              Elemental       `yaml:"elemental"`
 	SRIOV                  SRIOV           `yaml:"sriov"`
-	Akri                   HelmChart       `yaml:"akri"`
+	Akri                   Akri            `yaml:"akri"`
 	Metal3                 HelmChart       `yaml:"metal3"`
 }
 
@@ -64,5 +64,10 @@ type SRIOV struct {
 
 type KubeVirt struct {
 	KubeVirt           HelmChart `yaml:"kubevirt"`
+	DashboardExtension HelmChart `yaml:"dashboardExtension"`
+}
+
+type Akri struct {
+	Akri               HelmChart `yaml:"akri"`
 	DashboardExtension HelmChart `yaml:"dashboardExtension"`
 }


### PR DESCRIPTION
Screenshot of a successfully upgraded Akri chart, but failed add-on dashboard chart:
![Screenshot 2024-08-08 at 16 33 22](https://github.com/user-attachments/assets/07400c27-f81c-4560-b3d7-62b43791b3c5)

Screenshot of a successful Akri and dashboard upgrade:
![Screenshot 2024-08-08 at 16 10 46](https://github.com/user-attachments/assets/95c892cf-2906-4877-944f-aaac90bf2965)

Screenshot of a successful Akri upgrade when dashboard is missing:
![Screenshot 2024-08-08 at 16 18 46](https://github.com/user-attachments/assets/6ebed41e-2313-461f-8f59-d869ce39baa2)

Screenshot when Akri is missing, but dashboard is there/missing (it is the same output):
![Screenshot 2024-08-08 at 16 22 15](https://github.com/user-attachments/assets/1e8ab42f-4a26-406e-b5c4-6a112a233d74)
