### PR TITLE
Verify installation of dependency controllers

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -22,6 +22,12 @@ rules:
   - list
   - watch
 - apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - get
+- apiGroups:
   - batch
   resources:
   - jobs

--- a/internal/controller/upgradeplan_controller.go
+++ b/internal/controller/upgradeplan_controller.go
@@ -284,8 +284,8 @@ func (r *UpgradePlanReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		return fmt.Errorf("verifying Helm Controller installation: %w", err)
 	}
 
-	upgradePlanKind := upgradecattlev1.Kind(upgradecattlev1.PlanResourceName)
-	if _, err := definitionsGetter.Get(context.Background(), upgradePlanKind.String(), metav1.GetOptions{}); err != nil {
+	sucPlanKind := upgradecattlev1.Kind(upgradecattlev1.PlanResourceName)
+	if _, err := definitionsGetter.Get(context.Background(), sucPlanKind.String(), metav1.GetOptions{}); err != nil {
 		return fmt.Errorf("verifying System Upgrade Controller installation: %w", err)
 	}
 


### PR DESCRIPTION
- Ensures both Helm controller and SUC are present on start up
- If either of these are disabled or uninstalled at runtime, then the Upgrade controller will also be unable to work
  - In the future we might want to implement a CRD watching logic in a separate lightweight controller instance which would notify the main one for changes but this is currently out of scope