### PR TITLE
Specify watch namespace

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -121,11 +121,10 @@ func main() {
 			SecureServing: secureMetrics,
 			TLSOpts:       tlsOpts,
 		},
-		WebhookServer:           webhookServer,
-		HealthProbeBindAddress:  probeAddr,
-		LeaderElection:          enableLeaderElection,
-		LeaderElectionID:        "49a8982a.suse.com",
-		LeaderElectionNamespace: watchNamespace,
+		WebhookServer:          webhookServer,
+		HealthProbeBindAddress: probeAddr,
+		LeaderElection:         enableLeaderElection,
+		LeaderElectionID:       "49a8982a.suse.com",
 		// LeaderElectionReleaseOnCancel defines if the leader should step down voluntarily
 		// when the Manager ends. This requires the binary to immediately end when the
 		// Manager is stopped, otherwise, this setting is unsafe. Setting this significantly

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -75,7 +75,8 @@ func main() {
 		"If set the metrics endpoint is served securely")
 	flag.BoolVar(&enableHTTP2, "enable-http2", false,
 		"If set, HTTP/2 will be enabled for the metrics and webhook servers")
-	flag.StringVar(&watchNamespace, "namespace", os.Getenv("WATCH_NAMESPACE"), "Namespace that the controller watches to reconcile resources.")
+	flag.StringVar(&watchNamespace, "namespace", os.Getenv("WATCH_NAMESPACE"),
+		"Namespace that the controller watches to reconcile resources.")
 	opts := zap.Options{
 		Development: true,
 	}

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -29,6 +29,7 @@ import (
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/cache"
 	"sigs.k8s.io/controller-runtime/pkg/healthz"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
@@ -61,6 +62,8 @@ func main() {
 	var probeAddr string
 	var secureMetrics bool
 	var enableHTTP2 bool
+	var watchNamespace string
+
 	flag.StringVar(&metricsAddr, "metrics-bind-address", "0", "The address the metric endpoint binds to. "+
 		"Use the port :8080. If not set, it will be 0 in order to disable the metrics server")
 	flag.StringVar(&probeAddr, "health-probe-bind-address", ":8081", "The address the probe endpoint binds to.")
@@ -71,6 +74,7 @@ func main() {
 		"If set the metrics endpoint is served securely")
 	flag.BoolVar(&enableHTTP2, "enable-http2", false,
 		"If set, HTTP/2 will be enabled for the metrics and webhook servers")
+	flag.StringVar(&watchNamespace, "namespace", os.Getenv("WATCH_NAMESPACE"), "Namespace that the controller watches to reconcile resources.")
 	opts := zap.Options{
 		Development: true,
 	}
@@ -99,6 +103,13 @@ func main() {
 		TLSOpts: tlsOpts,
 	})
 
+	var watchNamespaces map[string]cache.Config
+	if watchNamespace != "" {
+		watchNamespaces = map[string]cache.Config{
+			watchNamespace: {},
+		}
+	}
+
 	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), ctrl.Options{
 		Scheme: scheme,
 		Metrics: metricsserver.Options{
@@ -106,10 +117,11 @@ func main() {
 			SecureServing: secureMetrics,
 			TLSOpts:       tlsOpts,
 		},
-		WebhookServer:          webhookServer,
-		HealthProbeBindAddress: probeAddr,
-		LeaderElection:         enableLeaderElection,
-		LeaderElectionID:       "49a8982a.suse.com",
+		WebhookServer:           webhookServer,
+		HealthProbeBindAddress:  probeAddr,
+		LeaderElection:          enableLeaderElection,
+		LeaderElectionID:        "49a8982a.suse.com",
+		LeaderElectionNamespace: watchNamespace,
 		// LeaderElectionReleaseOnCancel defines if the leader should step down voluntarily
 		// when the Manager ends. This requires the binary to immediately end when the
 		// Manager is stopped, otherwise, this setting is unsafe. Setting this significantly
@@ -121,6 +133,9 @@ func main() {
 		// if you are doing or is intended to do any operation such as perform cleanups
 		// after the manager stops then its usage might be unsafe.
 		// LeaderElectionReleaseOnCancel: true,
+		Cache: cache.Options{
+			DefaultNamespaces: watchNamespaces,
+		},
 	})
 	if err != nil {
 		setupLog.Error(err, "unable to start manager")

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -39,6 +39,7 @@ import (
 	upgradecattlev1 "github.com/rancher/system-upgrade-controller/pkg/apis/upgrade.cattle.io/v1"
 	lifecyclev1alpha1 "github.com/suse-edge/upgrade-controller/api/v1alpha1"
 	"github.com/suse-edge/upgrade-controller/internal/controller"
+	"github.com/suse-edge/upgrade-controller/internal/upgrade"
 	// +kubebuilder:scaffold:imports
 )
 
@@ -106,7 +107,9 @@ func main() {
 	var watchNamespaces map[string]cache.Config
 	if watchNamespace != "" {
 		watchNamespaces = map[string]cache.Config{
-			watchNamespace: {},
+			watchNamespace:             {},
+			upgrade.HelmChartNamespace: {},
+			upgrade.SUCNamespace:       {},
 		}
 	}
 

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -65,6 +65,11 @@ spec:
           - --health-probe-bind-address=:8081
         image: controller:latest
         name: manager
+        env:
+          - name: WATCH_NAMESPACE
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.namespace
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:

--- a/config/samples/lifecycle_v1alpha1_releasemanifest.yaml
+++ b/config/samples/lifecycle_v1alpha1_releasemanifest.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/name: upgrade-controller
     app.kubernetes.io/managed-by: kustomize
   name: releasemanifest-sample
-  namespace: cattle-system
+  namespace: upgrade-controller-system
 spec:
   releaseVersion: 3.0.1
   components:

--- a/config/samples/lifecycle_v1alpha1_upgradeplan.yaml
+++ b/config/samples/lifecycle_v1alpha1_upgradeplan.yaml
@@ -5,6 +5,6 @@ metadata:
     app.kubernetes.io/name: upgrade-controller
     app.kubernetes.io/managed-by: kustomize
   name: upgradeplan-sample
-  namespace: cattle-system
+  namespace: upgrade-controller-system
 spec:
   releaseVersion: 3.0.1

--- a/internal/controller/helm.go
+++ b/internal/controller/helm.go
@@ -72,7 +72,8 @@ func (r *UpgradePlanReconciler) updateHelmChart(ctx context.Context, upgradePlan
 	if chart.Annotations == nil {
 		chart.Annotations = map[string]string{}
 	}
-	chart.Annotations[upgrade.PlanAnnotation] = upgradePlan.Name
+	chart.Annotations[upgrade.PlanNameAnnotation] = upgradePlan.Name
+	chart.Annotations[upgrade.PlanNamespaceAnnotation] = upgradePlan.Namespace
 	chart.Annotations[upgrade.ReleaseAnnotation] = upgradePlan.Spec.ReleaseVersion
 	chart.Spec.ChartContent = ""
 	chart.Spec.Chart = releaseChart.Name
@@ -107,8 +108,9 @@ func (r *UpgradePlanReconciler) createHelmChart(ctx context.Context, upgradePlan
 			Name:      installedChart.Name,
 			Namespace: upgrade.ChartNamespace,
 			Annotations: map[string]string{
-				upgrade.PlanAnnotation:    upgradePlan.Name,
-				upgrade.ReleaseAnnotation: upgradePlan.Spec.ReleaseVersion,
+				upgrade.PlanNameAnnotation:      upgradePlan.Name,
+				upgrade.PlanNamespaceAnnotation: upgradePlan.Namespace,
+				upgrade.ReleaseAnnotation:       upgradePlan.Spec.ReleaseVersion,
 			},
 		},
 		Spec: helmcattlev1.HelmChartSpec{

--- a/internal/controller/helm.go
+++ b/internal/controller/helm.go
@@ -99,19 +99,18 @@ func (r *UpgradePlanReconciler) createHelmChart(ctx context.Context, upgradePlan
 		}
 	}
 
+	annotations := upgrade.PlanIdentifierAnnotations(upgradePlan.Name, upgradePlan.Namespace)
+	annotations[upgrade.ReleaseAnnotation] = upgradePlan.Spec.ReleaseVersion
+
 	chart := &helmcattlev1.HelmChart{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "HelmChart",
 			APIVersion: "helm.cattle.io/v1",
 		},
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      installedChart.Name,
-			Namespace: upgrade.HelmChartNamespace,
-			Annotations: map[string]string{
-				upgrade.PlanNameAnnotation:      upgradePlan.Name,
-				upgrade.PlanNamespaceAnnotation: upgradePlan.Namespace,
-				upgrade.ReleaseAnnotation:       upgradePlan.Spec.ReleaseVersion,
-			},
+			Name:        installedChart.Name,
+			Namespace:   upgrade.HelmChartNamespace,
+			Annotations: annotations,
 		},
 		Spec: helmcattlev1.HelmChartSpec{
 			Chart:           releaseChart.Name,

--- a/internal/controller/helm.go
+++ b/internal/controller/helm.go
@@ -106,7 +106,7 @@ func (r *UpgradePlanReconciler) createHelmChart(ctx context.Context, upgradePlan
 		},
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      installedChart.Name,
-			Namespace: upgrade.ChartNamespace,
+			Namespace: upgrade.HelmChartNamespace,
 			Annotations: map[string]string{
 				upgrade.PlanNameAnnotation:      upgradePlan.Name,
 				upgrade.PlanNamespaceAnnotation: upgradePlan.Namespace,
@@ -159,7 +159,7 @@ func (r *UpgradePlanReconciler) upgradeHelmChart(ctx context.Context, upgradePla
 	}
 
 	job := &batchv1.Job{}
-	if err = r.Get(ctx, types.NamespacedName{Name: chart.Status.JobName, Namespace: upgrade.ChartNamespace}, job); err != nil {
+	if err = r.Get(ctx, types.NamespacedName{Name: chart.Status.JobName, Namespace: upgrade.HelmChartNamespace}, job); err != nil {
 		return upgrade.ChartStateUnknown, client.IgnoreNotFound(err)
 	}
 

--- a/internal/controller/helm.go
+++ b/internal/controller/helm.go
@@ -122,7 +122,7 @@ func (r *UpgradePlanReconciler) createHelmChart(ctx context.Context, upgradePlan
 		},
 	}
 
-	return r.Create(ctx, chart)
+	return r.createObject(ctx, upgradePlan, chart)
 }
 
 func (r *UpgradePlanReconciler) upgradeHelmChart(ctx context.Context, upgradePlan *lifecyclev1alpha1.UpgradePlan, releaseChart *lifecyclev1alpha1.HelmChart) (upgrade.HelmChartState, error) {

--- a/internal/controller/reconcile_helm.go
+++ b/internal/controller/reconcile_helm.go
@@ -55,14 +55,14 @@ func (r *UpgradePlanReconciler) reconcileHelmChart(ctx context.Context, upgradeP
 
 			switch addonState {
 			case upgrade.ChartStateFailed:
-				msg := fmt.Sprintf("'%s' upgraded successfully, but add-on component '%s' failed to upgrade", chart.ReleaseName, addonChart.ReleaseName)
-				r.recordPlanEvent(upgradePlan, corev1.EventTypeWarning, conditionType, msg)
+				r.Recorder.Eventf(upgradePlan, corev1.EventTypeWarning, conditionType,
+					"'%s' upgraded successfully, but add-on component '%s' failed to upgrade", chart.ReleaseName, addonChart.ReleaseName)
 			case upgrade.ChartStateNotInstalled:
-				msg := fmt.Sprintf("'%s' add-on component upgrade skipped as it is missing in the cluster", addonChart.ReleaseName)
-				r.recordPlanEvent(upgradePlan, corev1.EventTypeNormal, conditionType, msg)
+				r.Recorder.Eventf(upgradePlan, corev1.EventTypeNormal, conditionType,
+					"'%s' add-on component upgrade skipped as it is missing in the cluster", addonChart.ReleaseName)
 			case upgrade.ChartStateSucceeded:
-				msg := fmt.Sprintf("'%s' add-on component successfully upgraded", addonChart.ReleaseName)
-				r.recordPlanEvent(upgradePlan, corev1.EventTypeNormal, conditionType, msg)
+				r.Recorder.Eventf(upgradePlan, corev1.EventTypeNormal, conditionType,
+					"'%s' add-on component successfully upgraded", addonChart.ReleaseName)
 			case upgrade.ChartStateInProgress:
 				// mark that current add-on chart upgrade is in progress
 				setInProgressCondition(upgradePlan, conditionType, addonState.FormattedMessage(addonChart.ReleaseName))

--- a/internal/controller/reconcile_kubernetes.go
+++ b/internal/controller/reconcile_kubernetes.go
@@ -35,7 +35,7 @@ func (r *UpgradePlanReconciler) reconcileKubernetes(ctx context.Context, upgrade
 		}
 
 		setInProgressCondition(upgradePlan, lifecyclev1alpha1.KubernetesUpgradedCondition, "Control plane nodes are being upgraded")
-		return ctrl.Result{}, r.createPlan(ctx, upgradePlan, controlPlanePlan)
+		return ctrl.Result{}, r.createObject(ctx, upgradePlan, controlPlanePlan)
 	}
 
 	selector, err := metav1.LabelSelectorAsSelector(controlPlanePlan.Spec.NodeSelector)
@@ -58,7 +58,7 @@ func (r *UpgradePlanReconciler) reconcileKubernetes(ctx context.Context, upgrade
 		}
 
 		setInProgressCondition(upgradePlan, lifecyclev1alpha1.KubernetesUpgradedCondition, "Worker nodes are being upgraded")
-		return ctrl.Result{}, r.createPlan(ctx, upgradePlan, workerPlan)
+		return ctrl.Result{}, r.createObject(ctx, upgradePlan, workerPlan)
 	}
 
 	selector, err = metav1.LabelSelectorAsSelector(workerPlan.Spec.NodeSelector)

--- a/internal/controller/reconcile_kubernetes.go
+++ b/internal/controller/reconcile_kubernetes.go
@@ -26,8 +26,9 @@ func (r *UpgradePlanReconciler) reconcileKubernetes(ctx context.Context, upgrade
 		return ctrl.Result{}, fmt.Errorf("identifying target kubernetes version: %w", err)
 	}
 
+	identifierAnnotations := upgrade.PlanIdentifierAnnotations(upgradePlan.Name, upgradePlan.Namespace)
 	drainControlPlane, drainWorker := parseDrainOptions(upgradePlan)
-	controlPlanePlan := upgrade.KubernetesControlPlanePlan(kubernetesVersion, drainControlPlane)
+	controlPlanePlan := upgrade.KubernetesControlPlanePlan(kubernetesVersion, drainControlPlane, identifierAnnotations)
 	if err = r.Get(ctx, client.ObjectKeyFromObject(controlPlanePlan), controlPlanePlan); err != nil {
 		if !errors.IsNotFound(err) {
 			return ctrl.Result{}, err
@@ -50,7 +51,7 @@ func (r *UpgradePlanReconciler) reconcileKubernetes(ctx context.Context, upgrade
 		return ctrl.Result{Requeue: true}, nil
 	}
 
-	workerPlan := upgrade.KubernetesWorkerPlan(kubernetesVersion, drainWorker)
+	workerPlan := upgrade.KubernetesWorkerPlan(kubernetesVersion, drainWorker, identifierAnnotations)
 	if err = r.Get(ctx, client.ObjectKeyFromObject(workerPlan), workerPlan); err != nil {
 		if !errors.IsNotFound(err) {
 			return ctrl.Result{}, err

--- a/internal/controller/reconcile_os.go
+++ b/internal/controller/reconcile_os.go
@@ -27,7 +27,7 @@ func (r *UpgradePlanReconciler) reconcileOS(ctx context.Context, upgradePlan *li
 			return ctrl.Result{}, err
 		}
 
-		return ctrl.Result{}, r.createSecret(ctx, upgradePlan, secret)
+		return ctrl.Result{}, r.createObject(ctx, upgradePlan, secret)
 	}
 
 	drainControlPlane, drainWorker := parseDrainOptions(upgradePlan)
@@ -38,7 +38,7 @@ func (r *UpgradePlanReconciler) reconcileOS(ctx context.Context, upgradePlan *li
 		}
 
 		setInProgressCondition(upgradePlan, lifecyclev1alpha1.OperatingSystemUpgradedCondition, "Control plane nodes are being upgraded")
-		return ctrl.Result{}, r.createPlan(ctx, upgradePlan, controlPlanePlan)
+		return ctrl.Result{}, r.createObject(ctx, upgradePlan, controlPlanePlan)
 	}
 
 	selector, err := metav1.LabelSelectorAsSelector(controlPlanePlan.Spec.NodeSelector)
@@ -66,7 +66,7 @@ func (r *UpgradePlanReconciler) reconcileOS(ctx context.Context, upgradePlan *li
 		}
 
 		setInProgressCondition(upgradePlan, lifecyclev1alpha1.OperatingSystemUpgradedCondition, "Worker nodes are being upgraded")
-		return ctrl.Result{}, r.createPlan(ctx, upgradePlan, workerPlan)
+		return ctrl.Result{}, r.createObject(ctx, upgradePlan, workerPlan)
 	}
 
 	selector, err = metav1.LabelSelectorAsSelector(workerPlan.Spec.NodeSelector)

--- a/internal/controller/upgradeplan_controller.go
+++ b/internal/controller/upgradeplan_controller.go
@@ -139,6 +139,7 @@ func (r *UpgradePlanReconciler) executePlan(ctx context.Context, upgradePlan *li
 }
 
 func (r *UpgradePlanReconciler) createObject(ctx context.Context, upgradePlan *lifecyclev1alpha1.UpgradePlan, object client.Object) error {
+	// Extract the kind first since the data of the object pointer is modified during creation.
 	kind := object.GetObjectKind().GroupVersionKind().Kind
 
 	if err := r.Create(ctx, object); err != nil {

--- a/internal/controller/upgradeplan_controller.go
+++ b/internal/controller/upgradeplan_controller.go
@@ -138,21 +138,16 @@ func (r *UpgradePlanReconciler) executePlan(ctx context.Context, upgradePlan *li
 	return ctrl.Result{}, nil
 }
 
-func (r *UpgradePlanReconciler) createSecret(ctx context.Context, upgradePlan *lifecyclev1alpha1.UpgradePlan, secret *corev1.Secret) error {
-	if err := r.Create(ctx, secret); err != nil {
-		return fmt.Errorf("creating secret: %w", err)
+func (r *UpgradePlanReconciler) createObject(ctx context.Context, upgradePlan *lifecyclev1alpha1.UpgradePlan, object client.Object) error {
+	kind := object.GetObjectKind().GroupVersionKind().Kind
+
+	if err := r.Create(ctx, object); err != nil {
+		return err
 	}
 
-	r.Recorder.Eventf(upgradePlan, corev1.EventTypeNormal, "SecretCreated", "Secret created: %s/%s", secret.Namespace, secret.Name)
-	return nil
-}
-
-func (r *UpgradePlanReconciler) createPlan(ctx context.Context, upgradePlan *lifecyclev1alpha1.UpgradePlan, plan *upgradecattlev1.Plan) error {
-	if err := r.Create(ctx, plan); err != nil {
-		return fmt.Errorf("creating upgrade plan: %w", err)
-	}
-
-	r.Recorder.Eventf(upgradePlan, corev1.EventTypeNormal, "PlanCreated", "Upgrade plan created: %s/%s", plan.Namespace, plan.Name)
+	reason := fmt.Sprintf("%sCreated", kind)
+	r.Recorder.Eventf(upgradePlan, corev1.EventTypeNormal, reason,
+		"%s created: %s/%s", kind, object.GetNamespace(), object.GetName())
 	return nil
 }
 

--- a/internal/controller/upgradeplan_controller.go
+++ b/internal/controller/upgradeplan_controller.go
@@ -143,7 +143,7 @@ func (r *UpgradePlanReconciler) createSecret(ctx context.Context, upgradePlan *l
 		return fmt.Errorf("creating secret: %w", err)
 	}
 
-	r.recordPlanEvent(upgradePlan, corev1.EventTypeNormal, "SecretCreated", fmt.Sprintf("Secret created: %s/%s", secret.Namespace, secret.Name))
+	r.Recorder.Eventf(upgradePlan, corev1.EventTypeNormal, "SecretCreated", "Secret created: %s/%s", secret.Namespace, secret.Name)
 	return nil
 }
 
@@ -152,12 +152,8 @@ func (r *UpgradePlanReconciler) createPlan(ctx context.Context, upgradePlan *lif
 		return fmt.Errorf("creating upgrade plan: %w", err)
 	}
 
-	r.recordPlanEvent(upgradePlan, corev1.EventTypeNormal, "PlanCreated", fmt.Sprintf("Upgrade plan created: %s/%s", plan.Namespace, plan.Name))
+	r.Recorder.Eventf(upgradePlan, corev1.EventTypeNormal, "PlanCreated", "Upgrade plan created: %s/%s", plan.Namespace, plan.Name)
 	return nil
-}
-
-func (r *UpgradePlanReconciler) recordPlanEvent(upgradePlan *lifecyclev1alpha1.UpgradePlan, eventType, reason, msg string) {
-	r.Recorder.Eventf(upgradePlan, eventType, reason, msg)
 }
 
 func isHelmUpgradeFinished(plan *lifecyclev1alpha1.UpgradePlan, conditionType string) bool {

--- a/internal/controller/upgradeplan_controller.go
+++ b/internal/controller/upgradeplan_controller.go
@@ -33,6 +33,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/record"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
@@ -257,14 +258,16 @@ func (r *UpgradePlanReconciler) findUpgradePlanFromJob(ctx context.Context, job 
 		return []reconcile.Request{}
 	}
 
-	planName, ok := helmChart.Annotations[upgrade.PlanAnnotation]
+	planName, ok := helmChart.Annotations[upgrade.PlanNameAnnotation]
 	if !ok || planName == "" {
 		// Helm chart is not managed by the Upgrade controller.
 		return []reconcile.Request{}
 	}
 
+	planNamespace := helmChart.Annotations[upgrade.PlanNamespaceAnnotation]
+
 	return []reconcile.Request{
-		{NamespacedName: upgrade.PlanNamespacedName(planName)},
+		{NamespacedName: types.NamespacedName{Namespace: planNamespace, Name: planName}},
 	}
 }
 

--- a/internal/upgrade/base.go
+++ b/internal/upgrade/base.go
@@ -21,7 +21,14 @@ const (
 	workersKey      = "workers"
 )
 
-func baseUpgradePlan(name string, drain bool) *upgradecattlev1.Plan {
+func PlanIdentifierAnnotations(name, namespace string) map[string]string {
+	return map[string]string{
+		PlanNameAnnotation:      name,
+		PlanNamespaceAnnotation: namespace,
+	}
+}
+
+func baseUpgradePlan(name string, drain bool, annotations map[string]string) *upgradecattlev1.Plan {
 	const (
 		kind               = "Plan"
 		apiVersion         = "upgrade.cattle.io/v1"
@@ -34,8 +41,9 @@ func baseUpgradePlan(name string, drain bool) *upgradecattlev1.Plan {
 			APIVersion: apiVersion,
 		},
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      name,
-			Namespace: SUCNamespace,
+			Name:        name,
+			Namespace:   SUCNamespace,
+			Annotations: annotations,
 		},
 		Spec: upgradecattlev1.PlanSpec{
 			ServiceAccountName: serviceAccountName,

--- a/internal/upgrade/base.go
+++ b/internal/upgrade/base.go
@@ -14,9 +14,11 @@ const (
 
 	ControlPlaneLabel = "node-role.kubernetes.io/control-plane"
 
-	upgradeNamespace = "cattle-system"
-	controlPlaneKey  = "control-plane"
-	workersKey       = "workers"
+	HelmChartNamespace = "kube-system"
+	SUCNamespace       = "cattle-system"
+
+	controlPlaneKey = "control-plane"
+	workersKey      = "workers"
 )
 
 func baseUpgradePlan(name string, drain bool) *upgradecattlev1.Plan {
@@ -33,7 +35,7 @@ func baseUpgradePlan(name string, drain bool) *upgradecattlev1.Plan {
 		},
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,
-			Namespace: upgradeNamespace,
+			Namespace: SUCNamespace,
 		},
 		Spec: upgradecattlev1.PlanSpec{
 			ServiceAccountName: serviceAccountName,

--- a/internal/upgrade/base.go
+++ b/internal/upgrade/base.go
@@ -5,17 +5,18 @@ import (
 
 	upgradecattlev1 "github.com/rancher/system-upgrade-controller/pkg/apis/upgrade.cattle.io/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/types"
 )
 
 const (
-	planNamespace     = "cattle-system"
-	PlanAnnotation    = "lifecycle.suse.com/upgrade-plan"
-	ReleaseAnnotation = "lifecycle.suse.com/release"
-	controlPlaneKey   = "control-plane"
-	workersKey        = "workers"
+	PlanNameAnnotation      = "lifecycle.suse.com/upgrade-plan-name"
+	PlanNamespaceAnnotation = "lifecycle.suse.com/upgrade-plan-namespace"
+	ReleaseAnnotation       = "lifecycle.suse.com/release"
 
 	ControlPlaneLabel = "node-role.kubernetes.io/control-plane"
+
+	upgradeNamespace = "cattle-system"
+	controlPlaneKey  = "control-plane"
+	workersKey       = "workers"
 )
 
 func baseUpgradePlan(name string, drain bool) *upgradecattlev1.Plan {
@@ -32,7 +33,7 @@ func baseUpgradePlan(name string, drain bool) *upgradecattlev1.Plan {
 		},
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,
-			Namespace: planNamespace,
+			Namespace: upgradeNamespace,
 		},
 		Spec: upgradecattlev1.PlanSpec{
 			ServiceAccountName: serviceAccountName,
@@ -52,11 +53,4 @@ func baseUpgradePlan(name string, drain bool) *upgradecattlev1.Plan {
 	}
 
 	return plan
-}
-
-func PlanNamespacedName(plan string) types.NamespacedName {
-	return types.NamespacedName{
-		Name:      plan,
-		Namespace: planNamespace,
-	}
 }

--- a/internal/upgrade/helm.go
+++ b/internal/upgrade/helm.go
@@ -6,14 +6,10 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 )
 
-const (
-	ChartNamespace = "kube-system"
-)
-
 func ChartNamespacedName(chart string) types.NamespacedName {
 	return types.NamespacedName{
 		Name:      chart,
-		Namespace: ChartNamespace,
+		Namespace: HelmChartNamespace,
 	}
 }
 

--- a/internal/upgrade/kubernetes.go
+++ b/internal/upgrade/kubernetes.go
@@ -26,11 +26,11 @@ func kubernetesUpgradeImage(version string) string {
 	return rke2UpgradeImage
 }
 
-func KubernetesControlPlanePlan(version string, drain bool) *upgradecattlev1.Plan {
+func KubernetesControlPlanePlan(version string, drain bool, annotations map[string]string) *upgradecattlev1.Plan {
 	controlPlanePlanName := kubernetesPlanName(controlPlaneKey, version)
 	upgradeImage := kubernetesUpgradeImage(version)
 
-	controlPlanePlan := baseUpgradePlan(controlPlanePlanName, drain)
+	controlPlanePlan := baseUpgradePlan(controlPlanePlanName, drain, annotations)
 	controlPlanePlan.Labels = map[string]string{
 		"k8s-upgrade": "control-plane",
 	}
@@ -75,12 +75,12 @@ func KubernetesControlPlanePlan(version string, drain bool) *upgradecattlev1.Pla
 	return controlPlanePlan
 }
 
-func KubernetesWorkerPlan(version string, drain bool) *upgradecattlev1.Plan {
+func KubernetesWorkerPlan(version string, drain bool, annotations map[string]string) *upgradecattlev1.Plan {
 	controlPlanePlanName := kubernetesPlanName(controlPlaneKey, version)
 	workerPlanName := kubernetesPlanName(workersKey, version)
 	upgradeImage := kubernetesUpgradeImage(version)
 
-	workerPlan := baseUpgradePlan(workerPlanName, drain)
+	workerPlan := baseUpgradePlan(workerPlanName, drain, annotations)
 	workerPlan.Labels = map[string]string{
 		"k8s-upgrade": "worker",
 	}

--- a/internal/upgrade/os.go
+++ b/internal/upgrade/os.go
@@ -54,7 +54,7 @@ func OSUpgradeSecret(releaseOS *lifecyclev1alpha1.OperatingSystem) (*corev1.Secr
 	secret := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      secretName,
-			Namespace: upgradeNamespace,
+			Namespace: SUCNamespace,
 		},
 		Type: corev1.SecretTypeOpaque,
 		StringData: map[string]string{

--- a/internal/upgrade/os.go
+++ b/internal/upgrade/os.go
@@ -24,6 +24,8 @@ var osUpgradeScript string
 
 func OSUpgradeSecret(releaseOS *lifecyclev1alpha1.OperatingSystem, annotations map[string]string) (*corev1.Secret, error) {
 	const (
+		apiVersion = "v1"
+		kind       = "Secret"
 		secretName = "os-upgrade-secret"
 	)
 
@@ -52,6 +54,10 @@ func OSUpgradeSecret(releaseOS *lifecyclev1alpha1.OperatingSystem, annotations m
 	}
 
 	secret := &corev1.Secret{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       kind,
+			APIVersion: apiVersion,
+		},
 		ObjectMeta: metav1.ObjectMeta{
 			Name:        secretName,
 			Namespace:   SUCNamespace,

--- a/internal/upgrade/os.go
+++ b/internal/upgrade/os.go
@@ -22,7 +22,7 @@ const (
 //go:embed templates/os-upgrade.sh.tpl
 var osUpgradeScript string
 
-func OSUpgradeSecret(releaseOS *lifecyclev1alpha1.OperatingSystem) (*corev1.Secret, error) {
+func OSUpgradeSecret(releaseOS *lifecyclev1alpha1.OperatingSystem, annotations map[string]string) (*corev1.Secret, error) {
 	const (
 		secretName = "os-upgrade-secret"
 	)
@@ -53,8 +53,9 @@ func OSUpgradeSecret(releaseOS *lifecyclev1alpha1.OperatingSystem) (*corev1.Secr
 
 	secret := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      secretName,
-			Namespace: SUCNamespace,
+			Name:        secretName,
+			Namespace:   SUCNamespace,
+			Annotations: annotations,
 		},
 		Type: corev1.SecretTypeOpaque,
 		StringData: map[string]string{
@@ -65,9 +66,9 @@ func OSUpgradeSecret(releaseOS *lifecyclev1alpha1.OperatingSystem) (*corev1.Secr
 	return secret, nil
 }
 
-func OSControlPlanePlan(releaseVersion, secretName string, releaseOS *lifecyclev1alpha1.OperatingSystem, drain bool) *upgradecattlev1.Plan {
+func OSControlPlanePlan(releaseVersion, secretName string, releaseOS *lifecyclev1alpha1.OperatingSystem, drain bool, annotations map[string]string) *upgradecattlev1.Plan {
 	controlPlanePlanName := osPlanName(controlPlaneKey, releaseOS.ZypperID, releaseOS.Version)
-	controlPlanePlan := baseOSPlan(controlPlanePlanName, releaseVersion, secretName, drain)
+	controlPlanePlan := baseOSPlan(controlPlanePlanName, releaseVersion, secretName, drain, annotations)
 
 	controlPlanePlan.Labels = map[string]string{
 		"os-upgrade": "control-plane",
@@ -108,9 +109,9 @@ func OSControlPlanePlan(releaseVersion, secretName string, releaseOS *lifecyclev
 	return controlPlanePlan
 }
 
-func OSWorkerPlan(releaseVersion, secretName string, releaseOS *lifecyclev1alpha1.OperatingSystem, drain bool) *upgradecattlev1.Plan {
+func OSWorkerPlan(releaseVersion, secretName string, releaseOS *lifecyclev1alpha1.OperatingSystem, drain bool, annotations map[string]string) *upgradecattlev1.Plan {
 	workerPlanName := osPlanName(workersKey, releaseOS.ZypperID, releaseOS.Version)
-	workerPlan := baseOSPlan(workerPlanName, releaseVersion, secretName, drain)
+	workerPlan := baseOSPlan(workerPlanName, releaseVersion, secretName, drain, annotations)
 
 	workerPlan.Labels = map[string]string{
 		"os-upgrade": "worker",
@@ -132,12 +133,12 @@ func OSWorkerPlan(releaseVersion, secretName string, releaseOS *lifecyclev1alpha
 	return workerPlan
 }
 
-func baseOSPlan(planName, releaseVersion, secretName string, drain bool) *upgradecattlev1.Plan {
+func baseOSPlan(planName, releaseVersion, secretName string, drain bool, annotations map[string]string) *upgradecattlev1.Plan {
 	const (
 		planImage = "registry.suse.com/bci/bci-base:15.5"
 	)
 
-	baseOSplan := baseUpgradePlan(planName, drain)
+	baseOSplan := baseUpgradePlan(planName, drain, annotations)
 
 	secretPathRelativeToHost := fmt.Sprintf("/run/system-upgrade/secrets/%s", secretName)
 	mountPath := filepath.Join("/host", secretPathRelativeToHost)

--- a/internal/upgrade/os.go
+++ b/internal/upgrade/os.go
@@ -54,7 +54,7 @@ func OSUpgradeSecret(releaseOS *lifecyclev1alpha1.OperatingSystem) (*corev1.Secr
 	secret := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      secretName,
-			Namespace: planNamespace,
+			Namespace: upgradeNamespace,
 		},
 		Type: corev1.SecretTypeOpaque,
 		StringData: map[string]string{


### PR DESCRIPTION
- Introduces a CLI arg (also configurable via env variable) to set watch namespace
  - The controller would only monitor for resources in said namespace if provided, or watch the whole cluster if not
- Drops controller references as those are no longer possible across different namespaces (i.e. an `UpgradePlan` created in the `upgrade-controller-system` namespace cannot be a parent of a `Secret` in the `cattle-system` namespace)
- Makes use of annotations to handle the connection between resources
- Records creation events of `HelmChart` resources
- **Does not** modify RBAC using kubebuilder since that would require a hardcoded namespace
  -  This will be revisited once we start working on a Helm chart