### PR TITLE
Move arch validation logic outside of OS upgrade script

### DIFF
--- a/api/v1alpha1/releasemanifest_types.go
+++ b/api/v1alpha1/releasemanifest_types.go
@@ -17,7 +17,14 @@ limitations under the License.
 package v1alpha1
 
 import (
+	"fmt"
+
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+const (
+	ArchTypeX86 Arch = "x86_64"
+	ArchTypeARM Arch = "aarch64"
 )
 
 // ReleaseManifestSpec defines the desired state of ReleaseManifest
@@ -65,12 +72,28 @@ type KubernetesDistribution struct {
 }
 
 type OperatingSystem struct {
-	Version        string   `json:"version"`
-	ZypperID       string   `json:"zypperID"`
-	CPEScheme      string   `json:"cpeScheme"`
-	RepoGPGPath    string   `json:"repoGPGPath"`
-	SupportedArchs []string `json:"supportedArchs"`
-	PrettyName     string   `json:"prettyName"`
+	Version     string `json:"version"`
+	ZypperID    string `json:"zypperID"`
+	CPEScheme   string `json:"cpeScheme"`
+	RepoGPGPath string `json:"repoGPGPath"`
+	// +kubebuilder:validation:MinItems=1
+	SupportedArchs []Arch `json:"supportedArchs"`
+	PrettyName     string `json:"prettyName"`
+}
+
+// +kubebuilder:validation:Enum=x86_64;aarch64
+type Arch string
+
+func (a Arch) Short() string {
+	switch a {
+	case ArchTypeX86:
+		return "amd64"
+	case ArchTypeARM:
+		return "arm64"
+	default:
+		message := fmt.Sprintf("unknown arch: %s", a)
+		panic(message)
+	}
 }
 
 // +kubebuilder:object:root=true

--- a/api/v1alpha1/zz_generated.deepcopy.go
+++ b/api/v1alpha1/zz_generated.deepcopy.go
@@ -134,7 +134,7 @@ func (in *OperatingSystem) DeepCopyInto(out *OperatingSystem) {
 	*out = *in
 	if in.SupportedArchs != nil {
 		in, out := &in.SupportedArchs, &out.SupportedArchs
-		*out = make([]string, len(*in))
+		*out = make([]Arch, len(*in))
 		copy(*out, *in)
 	}
 }

--- a/config/crd/bases/lifecycle.suse.com_releasemanifests.yaml
+++ b/config/crd/bases/lifecycle.suse.com_releasemanifests.yaml
@@ -71,7 +71,11 @@ spec:
                         type: string
                       supportedArchs:
                         items:
+                          enum:
+                          - x86_64
+                          - aarch64
                           type: string
+                        minItems: 1
                         type: array
                       version:
                         type: string

--- a/internal/upgrade/os.go
+++ b/internal/upgrade/os.go
@@ -35,17 +35,15 @@ func OSUpgradeSecret(releaseOS *lifecyclev1alpha1.OperatingSystem, annotations m
 	}
 
 	values := struct {
-		CPEScheme      string
-		RepoGPGKey     string
-		ZypperID       string
-		Version        string
-		SupportedArchs []string
+		CPEScheme  string
+		RepoGPGKey string
+		ZypperID   string
+		Version    string
 	}{
-		CPEScheme:      releaseOS.CPEScheme,
-		RepoGPGKey:     releaseOS.RepoGPGPath,
-		ZypperID:       releaseOS.ZypperID,
-		Version:        releaseOS.Version,
-		SupportedArchs: releaseOS.SupportedArchs,
+		CPEScheme:  releaseOS.CPEScheme,
+		RepoGPGKey: releaseOS.RepoGPGPath,
+		ZypperID:   releaseOS.ZypperID,
+		Version:    releaseOS.Version,
 	}
 
 	var buff bytes.Buffer

--- a/internal/upgrade/templates/os-upgrade.sh.tpl
+++ b/internal/upgrade/templates/os-upgrade.sh.tpl
@@ -25,23 +25,7 @@ executeUpgrade(){
     # Common Platform Enumeration (CPE) that the system is currently running with
     CURRENT_CPE=`cat /etc/os-release | grep -w CPE_NAME | cut -d "=" -f 2 | tr -d '"'`
 
-    # Determine whether architecture is supported
     SYSTEM_ARCH=`arch`
-    IFS=' ' read -r -a SUPPORTED_ARCH_ARRAY <<< $(echo "{{.SupportedArchs}}" | tr -d '[]')
-
-    found=false
-    for arch in "${SUPPORTED_ARCH_ARRAY[@]}"; do
-        if [ "${SYSTEM_ARCH}" == ${arch} ]; then
-            found=true
-            break
-        fi
-    done
-
-    if [ ${found} == false ]; then
-        echo "Operating system is running an unsupported architecture. System arch: ${SYSTEM_ARCH}. Supported archs: ${SUPPORTED_ARCH_ARRAY[*]}"
-        exit 1
-    fi
-
     # Lines that will be appended to the systemd.service 'ExecStartPre' configuration
     EXEC_START_PRE_LINES=""
 


### PR DESCRIPTION
The suggested implementation introduces the following changes:
1. Removal of the existing OS arch validation that was located in the `os-upgrade.sh.tpl` script template
2. Rework of the `SupportedArchs` property of the `OperatingSystem` release manifest configuration:
     - The property has been moved away from a `[]string` to a `[]Arch` type
     - Validation was added for each `Arch` entry that it holds expected full arch names - `x86_64` and `aarch64` have been added as initial possible configurations.
     - Logic that converts arch full names to short names (e.g. `amd64`, `arm64`.. etc.) was added.
3. OS arch validation is now done by the `upgrade-controller`, where:
     - each cluster node is validated against the supported architectures (both full name and short name) that have been defined in the release manifest
     - if a node is not running a supported architecture, the OS upgrade fails and both a condition and error message are printed in the `UpgradePlan` and `upgrade-controller` respectively.

Example "Failed" `UpgradePlan` condition message:
```yaml
apiVersion: lifecycle.suse.com/v1alpha1
kind: UpgradePlan
..
  name: upgradeplan-sample
  namespace: upgrade-controller-system
..
status:
  conditions:
  - lastTransitionTime: "2024-08-21T09:05:32Z"
    message: Cluster nodes are running unsupported architectures
    reason: Failed
    status: "False"
    type: OSUpgraded
```

Example error message in the `upgrade-controller` for the following `ReleaseManifest` configuration:
ReleaseManifest:
```yaml
apiVersion: lifecycle.suse.com/v1alpha1
kind: ReleaseManifest
metadata:
  name: releasemanifest-sample
  namespace: upgrade-controller-system
spec:
...
    operatingSystem:
      ...
      supportedArchs:
        - "aarch64"
```

`upgrade-controller` error message when running on a `x86_64` OS arch:
```yaml
2024-08-21T09:05:42Z  ERROR Reconciler error  {"controller": "upgradeplan", "controllerGroup": "lifecycle.suse.com", "controllerKind": "UpgradePlan", "UpgradePlan": {"name":"upgradeplan-sample","namespace":"upgrade-controller-system"}, "namespace": "upgrade-controller-system", "name": "upgradeplan-sample", "reconcileID": "208a11db-f2d9-47d8-8048-53a2f67fdd20", "error": "validating cluster node OS architecture: unsuported arch 'amd64' for 'mgmt-cluster-network' node. Supported archs: [aarch64]"}
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).reconcileHandler
  /go/pkg/mod/sigs.k8s.io/controller-runtime@v0.19.0/pkg/internal/controller/controller.go:316
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).processNextWorkItem
  /go/pkg/mod/sigs.k8s.io/controller-runtime@v0.19.0/pkg/internal/controller/controller.go:263
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).Start.func2.2
  /go/pkg/mod/sigs.k8s.io/controller-runtime@v0.19.0/pkg/internal/controller/controller.go:224
```

Was tested both for failure and successful use-cases.