### PR TITLE
Allow custom helm values

### DIFF
--- a/api/v1alpha1/releasemanifest_types.go
+++ b/api/v1alpha1/releasemanifest_types.go
@@ -19,6 +19,7 @@ package v1alpha1
 import (
 	"fmt"
 
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -48,11 +49,12 @@ type Workloads struct {
 }
 
 type HelmChart struct {
-	ReleaseName string `json:"releaseName"`
-	Name        string `json:"chart"`
-	Repository  string `json:"repository,omitempty"`
-	Version     string `json:"version"`
-	PrettyName  string `json:"prettyName"`
+	ReleaseName string                `json:"releaseName"`
+	Name        string                `json:"chart"`
+	Repository  string                `json:"repository,omitempty"`
+	Version     string                `json:"version"`
+	PrettyName  string                `json:"prettyName"`
+	Values      *apiextensionsv1.JSON `json:"values,omitempty"`
 
 	// +kubebuilder:pruning:PreserveUnknownFields
 	// +kubebuilder:validation:Schemaless

--- a/api/v1alpha1/upgradeplan_types.go
+++ b/api/v1alpha1/upgradeplan_types.go
@@ -19,6 +19,7 @@ package v1alpha1
 import (
 	"fmt"
 
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -53,6 +54,12 @@ type UpgradePlanSpec struct {
 	// DisableDrain specifies whether control-plane and worker nodes drain should be disabled.
 	// +optional
 	DisableDrain DisableDrain `json:"disableDrain"`
+	// HelmValues specifies additional values for components installed via Helm.
+	// It is only advised to use this field for values that are critical for upgrades.
+	// Standard chart value updates should be performed after
+	// the respective charts have been upgraded to the next version.
+	// +optional
+	HelmValues []HelmValues `json:"helmValues"`
 }
 
 type DisableDrain struct {
@@ -60,6 +67,11 @@ type DisableDrain struct {
 	ControlPlane bool `json:"controlPlane"`
 	// +optional
 	Worker bool `json:"worker"`
+}
+
+type HelmValues struct {
+	Chart  string                `json:"chart"`
+	Values *apiextensionsv1.JSON `json:"values"`
 }
 
 // UpgradePlanStatus defines the observed state of UpgradePlan

--- a/api/v1alpha1/upgradeplan_types.go
+++ b/api/v1alpha1/upgradeplan_types.go
@@ -54,12 +54,12 @@ type UpgradePlanSpec struct {
 	// DisableDrain specifies whether control-plane and worker nodes drain should be disabled.
 	// +optional
 	DisableDrain DisableDrain `json:"disableDrain"`
-	// HelmValues specifies additional values for components installed via Helm.
+	// Helm specifies additional values for components installed via Helm.
 	// It is only advised to use this field for values that are critical for upgrades.
 	// Standard chart value updates should be performed after
 	// the respective charts have been upgraded to the next version.
 	// +optional
-	HelmValues []HelmValues `json:"helmValues"`
+	Helm []HelmValues `json:"helm"`
 }
 
 type DisableDrain struct {

--- a/config/crd/bases/lifecycle.suse.com_releasemanifests.yaml
+++ b/config/crd/bases/lifecycle.suse.com_releasemanifests.yaml
@@ -106,6 +106,8 @@ spec:
                               type: string
                             repository:
                               type: string
+                            values:
+                              x-kubernetes-preserve-unknown-fields: true
                             version:
                               type: string
                           required:

--- a/config/crd/bases/lifecycle.suse.com_upgradeplans.yaml
+++ b/config/crd/bases/lifecycle.suse.com_upgradeplans.yaml
@@ -48,9 +48,9 @@ spec:
                   worker:
                     type: boolean
                 type: object
-              helmValues:
+              helm:
                 description: |-
-                  HelmValues specifies additional values for components installed via Helm.
+                  Helm specifies additional values for components installed via Helm.
                   It is only advised to use this field for values that are critical for upgrades.
                   Standard chart value updates should be performed after
                   the respective charts have been upgraded to the next version.

--- a/config/crd/bases/lifecycle.suse.com_upgradeplans.yaml
+++ b/config/crd/bases/lifecycle.suse.com_upgradeplans.yaml
@@ -48,6 +48,23 @@ spec:
                   worker:
                     type: boolean
                 type: object
+              helmValues:
+                description: |-
+                  HelmValues specifies additional values for components installed via Helm.
+                  It is only advised to use this field for values that are critical for upgrades.
+                  Standard chart value updates should be performed after
+                  the respective charts have been upgraded to the next version.
+                items:
+                  properties:
+                    chart:
+                      type: string
+                    values:
+                      x-kubernetes-preserve-unknown-fields: true
+                  required:
+                  - chart
+                  - values
+                  type: object
+                type: array
               releaseVersion:
                 description: |-
                   ReleaseVersion specifies the target version for platform upgrade.

--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/onsi/ginkgo/v2 v2.20.0
 	github.com/onsi/gomega v1.34.1
 	github.com/rancher/system-upgrade-controller/pkg/apis v0.0.0-20240612205712-57605e3390c0
+	github.com/stretchr/testify v1.9.0
 	helm.sh/helm/v3 v3.15.3
 	k8s.io/api v0.31.0
 	k8s.io/apiextensions-apiserver v0.31.0
@@ -58,6 +59,7 @@ require (
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
+	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
 	github.com/prometheus/client_golang v1.19.1 // indirect
 	github.com/prometheus/client_model v0.6.1 // indirect
 	github.com/prometheus/common v0.55.0 // indirect

--- a/internal/controller/helm.go
+++ b/internal/controller/helm.go
@@ -72,7 +72,7 @@ func (r *UpgradePlanReconciler) updateHelmChart(ctx context.Context, upgradePlan
 	backoffLimit := int32(6)
 
 	var userValues *apiextensionsv1.JSON
-	for _, h := range upgradePlan.Spec.HelmValues {
+	for _, h := range upgradePlan.Spec.Helm {
 		if releaseChart.Name == h.Chart {
 			userValues = h.Values
 			break
@@ -106,7 +106,7 @@ func (r *UpgradePlanReconciler) createHelmChart(ctx context.Context, upgradePlan
 	backoffLimit := int32(6)
 
 	var userValues *apiextensionsv1.JSON
-	for _, h := range upgradePlan.Spec.HelmValues {
+	for _, h := range upgradePlan.Spec.Helm {
 		if releaseChart.Name == h.Chart {
 			userValues = h.Values
 			break

--- a/internal/controller/helm.go
+++ b/internal/controller/helm.go
@@ -201,9 +201,9 @@ func mergeMaps(m1, m2 map[string]any) map[string]any {
 	}
 
 	for k, v := range m2 {
-		if v, ok := v.(map[string]any); ok {
-			if inner, ok := out[k].(map[string]any); ok {
-				out[k] = mergeMaps(inner, v)
+		if inner, ok := v.(map[string]any); ok {
+			if outInner, ok := out[k].(map[string]any); ok {
+				out[k] = mergeMaps(outInner, inner)
 				continue
 			}
 		}

--- a/internal/controller/helm_test.go
+++ b/internal/controller/helm_test.go
@@ -13,7 +13,8 @@ func Test_MergeHelmValues(t *testing.T) {
 	tests := []struct {
 		name            string
 		installedValues any
-		newValues       *apiextensionsv1.JSON
+		releaseValues   *apiextensionsv1.JSON
+		userValues      *apiextensionsv1.JSON
 		expectedValues  []byte
 		expectedErr     string
 	}{
@@ -23,46 +24,46 @@ func Test_MergeHelmValues(t *testing.T) {
 			expectedErr:     "unexpected type int of installed values",
 		},
 		{
-			name:            "Empty installed values string, empty new values",
+			name:            "Empty installed values string, empty release values",
 			installedValues: "",
 			expectedValues:  nil,
 		},
 		{
-			name:            "Empty installed values string, non-empty new values",
+			name:            "Empty installed values string, non-empty release values",
 			installedValues: "",
-			newValues: &apiextensionsv1.JSON{
+			releaseValues: &apiextensionsv1.JSON{
 				Raw: []byte(`{"global": {"ironicIP": "147.28.230.5"}}`),
 			},
 			expectedValues: []byte(`{"global":{"ironicIP":"147.28.230.5"}}`),
 		},
 		{
-			name:            "Non-empty installed values string, empty new values",
+			name:            "Non-empty installed values string, empty release values",
 			installedValues: `{"global":{"ironicIP":"147.28.230.5"},"metal3-mariadb":{"persistence":{"storageClass":"longhorn"}}}`,
 			expectedValues:  []byte(`{"global":{"ironicIP":"147.28.230.5"},"metal3-mariadb":{"persistence":{"storageClass":"longhorn"}}}`),
 		},
 		{
-			name:            "Non-empty installed values string, non-empty new values",
+			name:            "Non-empty installed values string, non-empty release values",
 			installedValues: `{"global":{"ironicIP":"147.28.230.5"},"metal3-mariadb":{"persistence":{"storageClass":"longhorn"}}}`,
-			newValues: &apiextensionsv1.JSON{
+			releaseValues: &apiextensionsv1.JSON{
 				Raw: []byte(`{"global": {"ironicIP": "147.28.230.105"}}`),
 			},
 			expectedValues: []byte(`{"global":{"ironicIP":"147.28.230.105"},"metal3-mariadb":{"persistence":{"storageClass":"longhorn"}}}`),
 		},
 		{
-			name:            "Empty installed values map, empty new values",
+			name:            "Empty installed values map, empty release values",
 			installedValues: map[string]interface{}{},
 			expectedValues:  nil,
 		},
 		{
-			name:            "Empty installed values map, non-empty new values",
+			name:            "Empty installed values map, non-empty release values",
 			installedValues: map[string]interface{}{},
-			newValues: &apiextensionsv1.JSON{
+			releaseValues: &apiextensionsv1.JSON{
 				Raw: []byte(`{"global": {"ironicIP": "147.28.230.5"}}`),
 			},
 			expectedValues: []byte(`{"global":{"ironicIP":"147.28.230.5"}}`),
 		},
 		{
-			name: "Non-empty installed values map, empty new values",
+			name: "Non-empty installed values map, empty release values",
 			installedValues: map[string]interface{}{
 				"global": map[string]interface{}{
 					"ironicIP": "147.28.230.5",
@@ -76,7 +77,7 @@ func Test_MergeHelmValues(t *testing.T) {
 			expectedValues: []byte(`{"global":{"ironicIP":"147.28.230.5"},"metal3-mariadb":{"persistence":{"storageClass":"longhorn"}}}`),
 		},
 		{
-			name: "Non-empty installed values map, non-empty new values",
+			name: "Non-empty installed values map, non-empty release values",
 			installedValues: map[string]interface{}{
 				"global": map[string]interface{}{
 					"ironicIP": "147.28.230.5",
@@ -87,10 +88,30 @@ func Test_MergeHelmValues(t *testing.T) {
 					},
 				},
 			},
-			newValues: &apiextensionsv1.JSON{
+			releaseValues: &apiextensionsv1.JSON{
 				Raw: []byte(`{"global": {"ironicIP": "147.28.230.105"}}`),
 			},
 			expectedValues: []byte(`{"global":{"ironicIP":"147.28.230.105"},"metal3-mariadb":{"persistence":{"storageClass":"longhorn"}}}`),
+		},
+		{
+			name: "Non-empty installed values map, non-empty release values, non-empty user values",
+			installedValues: map[string]interface{}{
+				"global": map[string]interface{}{
+					"ironicIP": "147.28.230.5",
+				},
+				"metal3-mariadb": map[string]interface{}{
+					"persistence": map[string]string{
+						"storageClass": "longhorn",
+					},
+				},
+			},
+			releaseValues: &apiextensionsv1.JSON{
+				Raw: []byte(`{"global": {"ironicIP": "147.28.230.105"}}`),
+			},
+			userValues: &apiextensionsv1.JSON{
+				Raw: []byte(`{"metal3-ironic": {"persistence": {"ironic": {"storageClass": "longhorn"}}}}`),
+			},
+			expectedValues: []byte(`{"global":{"ironicIP":"147.28.230.105"},"metal3-ironic":{"persistence":{"ironic":{"storageClass":"longhorn"}}},"metal3-mariadb":{"persistence":{"storageClass":"longhorn"}}}`),
 		},
 		{
 			name:            "Invalid installed values string",
@@ -98,18 +119,26 @@ func Test_MergeHelmValues(t *testing.T) {
 			expectedErr:     "unmarshaling installed chart values: unexpected end of JSON input",
 		},
 		{
-			name:            "Invalid new values",
+			name:            "Invalid release values",
 			installedValues: "",
-			newValues: &apiextensionsv1.JSON{
+			releaseValues: &apiextensionsv1.JSON{
 				Raw: []byte(`{`),
 			},
-			expectedErr: "unmarshaling additional chart values: unexpected end of JSON input",
+			expectedErr: "unmarshaling additional release values: unexpected end of JSON input",
+		},
+		{
+			name:            "Invalid user values",
+			installedValues: "",
+			userValues: &apiextensionsv1.JSON{
+				Raw: []byte(`{`),
+			},
+			expectedErr: "unmarshaling additional user values: unexpected end of JSON input",
 		},
 	}
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			values, err := mergeHelmValues(test.installedValues, test.newValues)
+			values, err := mergeHelmValues(test.installedValues, test.releaseValues, test.userValues)
 			if test.expectedErr != "" {
 				require.Error(t, err)
 				assert.EqualError(t, err, test.expectedErr)

--- a/internal/controller/helm_test.go
+++ b/internal/controller/helm_test.go
@@ -10,6 +10,38 @@ import (
 )
 
 func Test_MergeHelmValues(t *testing.T) {
+	installedValuesStr := `{
+  "global": {
+    "ironicIP": "147.28.230.5"
+  },
+  "metal3-ironic": {
+    "service": {
+      "type": "LoadBalancer"
+    },
+    "persistence": {
+      "ironic": {
+        "storageClass": "longhorn"
+      }
+    }
+  }
+}`
+
+	installedValuesMap := map[string]interface{}{
+		"global": map[string]interface{}{
+			"ironicIP": "147.28.230.5",
+		},
+		"metal3-ironic": map[string]interface{}{
+			"service": map[string]interface{}{
+				"type": "LoadBalancer",
+			},
+			"persistence": map[string]interface{}{
+				"ironic": map[string]interface{}{
+					"storageClass": "longhorn",
+				},
+			},
+		},
+	}
+
 	tests := []struct {
 		name            string
 		installedValues any
@@ -38,16 +70,16 @@ func Test_MergeHelmValues(t *testing.T) {
 		},
 		{
 			name:            "Non-empty installed values string, empty release values",
-			installedValues: `{"global":{"ironicIP":"147.28.230.5"},"metal3-mariadb":{"persistence":{"storageClass":"longhorn"}}}`,
-			expectedValues:  []byte(`{"global":{"ironicIP":"147.28.230.5"},"metal3-mariadb":{"persistence":{"storageClass":"longhorn"}}}`),
+			installedValues: installedValuesStr,
+			expectedValues:  []byte(`{"global":{"ironicIP":"147.28.230.5"},"metal3-ironic":{"persistence":{"ironic":{"storageClass":"longhorn"}},"service":{"type":"LoadBalancer"}}}`),
 		},
 		{
 			name:            "Non-empty installed values string, non-empty release values",
-			installedValues: `{"global":{"ironicIP":"147.28.230.5"},"metal3-mariadb":{"persistence":{"storageClass":"longhorn"}}}`,
+			installedValues: installedValuesStr,
 			releaseValues: &apiextensionsv1.JSON{
 				Raw: []byte(`{"global": {"ironicIP": "147.28.230.105"}}`),
 			},
-			expectedValues: []byte(`{"global":{"ironicIP":"147.28.230.105"},"metal3-mariadb":{"persistence":{"storageClass":"longhorn"}}}`),
+			expectedValues: []byte(`{"global":{"ironicIP":"147.28.230.105"},"metal3-ironic":{"persistence":{"ironic":{"storageClass":"longhorn"}},"service":{"type":"LoadBalancer"}}}`),
 		},
 		{
 			name:            "Empty installed values map, empty release values",
@@ -63,55 +95,28 @@ func Test_MergeHelmValues(t *testing.T) {
 			expectedValues: []byte(`{"global":{"ironicIP":"147.28.230.5"}}`),
 		},
 		{
-			name: "Non-empty installed values map, empty release values",
-			installedValues: map[string]interface{}{
-				"global": map[string]interface{}{
-					"ironicIP": "147.28.230.5",
-				},
-				"metal3-mariadb": map[string]interface{}{
-					"persistence": map[string]string{
-						"storageClass": "longhorn",
-					},
-				},
-			},
-			expectedValues: []byte(`{"global":{"ironicIP":"147.28.230.5"},"metal3-mariadb":{"persistence":{"storageClass":"longhorn"}}}`),
+			name:            "Non-empty installed values map, empty release values",
+			installedValues: installedValuesMap,
+			expectedValues:  []byte(`{"global":{"ironicIP":"147.28.230.5"},"metal3-ironic":{"persistence":{"ironic":{"storageClass":"longhorn"}},"service":{"type":"LoadBalancer"}}}`),
 		},
 		{
-			name: "Non-empty installed values map, non-empty release values",
-			installedValues: map[string]interface{}{
-				"global": map[string]interface{}{
-					"ironicIP": "147.28.230.5",
-				},
-				"metal3-mariadb": map[string]interface{}{
-					"persistence": map[string]string{
-						"storageClass": "longhorn",
-					},
-				},
-			},
+			name:            "Non-empty installed values map, non-empty release values",
+			installedValues: installedValuesMap,
 			releaseValues: &apiextensionsv1.JSON{
 				Raw: []byte(`{"global": {"ironicIP": "147.28.230.105"}}`),
 			},
-			expectedValues: []byte(`{"global":{"ironicIP":"147.28.230.105"},"metal3-mariadb":{"persistence":{"storageClass":"longhorn"}}}`),
+			expectedValues: []byte(`{"global":{"ironicIP":"147.28.230.105"},"metal3-ironic":{"persistence":{"ironic":{"storageClass":"longhorn"}},"service":{"type":"LoadBalancer"}}}`),
 		},
 		{
-			name: "Non-empty installed values map, non-empty release values, non-empty user values",
-			installedValues: map[string]interface{}{
-				"global": map[string]interface{}{
-					"ironicIP": "147.28.230.5",
-				},
-				"metal3-mariadb": map[string]interface{}{
-					"persistence": map[string]string{
-						"storageClass": "longhorn",
-					},
-				},
-			},
+			name:            "Non-empty installed values map, non-empty release values, non-empty user values",
+			installedValues: installedValuesMap,
 			releaseValues: &apiextensionsv1.JSON{
 				Raw: []byte(`{"global": {"ironicIP": "147.28.230.105"}}`),
 			},
 			userValues: &apiextensionsv1.JSON{
-				Raw: []byte(`{"metal3-ironic": {"persistence": {"ironic": {"storageClass": "longhorn"}}}}`),
+				Raw: []byte(`{"metal3-ironic": {"persistence": {"ironic": {"storageClass": "local-path-provisioner"}}}}`),
 			},
-			expectedValues: []byte(`{"global":{"ironicIP":"147.28.230.105"},"metal3-ironic":{"persistence":{"ironic":{"storageClass":"longhorn"}}},"metal3-mariadb":{"persistence":{"storageClass":"longhorn"}}}`),
+			expectedValues: []byte(`{"global":{"ironicIP":"147.28.230.105"},"metal3-ironic":{"persistence":{"ironic":{"storageClass":"local-path-provisioner"}},"service":{"type":"LoadBalancer"}}}`),
 		},
 		{
 			name:            "Invalid installed values string",

--- a/internal/controller/helm_test.go
+++ b/internal/controller/helm_test.go
@@ -1,0 +1,123 @@
+package controller
+
+import (
+	"testing"
+
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func Test_MergeHelmValues(t *testing.T) {
+	tests := []struct {
+		name            string
+		installedValues any
+		newValues       *apiextensionsv1.JSON
+		expectedValues  []byte
+		expectedErr     string
+	}{
+		{
+			name:            "Invalid type of installed values",
+			installedValues: 5,
+			expectedErr:     "unexpected type int of installed values",
+		},
+		{
+			name:            "Empty installed values string, empty new values",
+			installedValues: "",
+			expectedValues:  nil,
+		},
+		{
+			name:            "Empty installed values string, non-empty new values",
+			installedValues: "",
+			newValues: &apiextensionsv1.JSON{
+				Raw: []byte(`{"global": {"ironicIP": "147.28.230.5"}}`),
+			},
+			expectedValues: []byte(`{"global":{"ironicIP":"147.28.230.5"}}`),
+		},
+		{
+			name:            "Non-empty installed values string, empty new values",
+			installedValues: `{"global":{"ironicIP":"147.28.230.5"},"metal3-mariadb":{"persistence":{"storageClass":"longhorn"}}}`,
+			expectedValues:  []byte(`{"global":{"ironicIP":"147.28.230.5"},"metal3-mariadb":{"persistence":{"storageClass":"longhorn"}}}`),
+		},
+		{
+			name:            "Non-empty installed values string, non-empty new values",
+			installedValues: `{"global":{"ironicIP":"147.28.230.5"},"metal3-mariadb":{"persistence":{"storageClass":"longhorn"}}}`,
+			newValues: &apiextensionsv1.JSON{
+				Raw: []byte(`{"global": {"ironicIP": "147.28.230.105"}}`),
+			},
+			expectedValues: []byte(`{"global":{"ironicIP":"147.28.230.105"},"metal3-mariadb":{"persistence":{"storageClass":"longhorn"}}}`),
+		},
+		{
+			name:            "Empty installed values map, empty new values",
+			installedValues: map[string]interface{}{},
+			expectedValues:  nil,
+		},
+		{
+			name:            "Empty installed values map, non-empty new values",
+			installedValues: map[string]interface{}{},
+			newValues: &apiextensionsv1.JSON{
+				Raw: []byte(`{"global": {"ironicIP": "147.28.230.5"}}`),
+			},
+			expectedValues: []byte(`{"global":{"ironicIP":"147.28.230.5"}}`),
+		},
+		{
+			name: "Non-empty installed values map, empty new values",
+			installedValues: map[string]interface{}{
+				"global": map[string]interface{}{
+					"ironicIP": "147.28.230.5",
+				},
+				"metal3-mariadb": map[string]interface{}{
+					"persistence": map[string]string{
+						"storageClass": "longhorn",
+					},
+				},
+			},
+			expectedValues: []byte(`{"global":{"ironicIP":"147.28.230.5"},"metal3-mariadb":{"persistence":{"storageClass":"longhorn"}}}`),
+		},
+		{
+			name: "Non-empty installed values map, non-empty new values",
+			installedValues: map[string]interface{}{
+				"global": map[string]interface{}{
+					"ironicIP": "147.28.230.5",
+				},
+				"metal3-mariadb": map[string]interface{}{
+					"persistence": map[string]string{
+						"storageClass": "longhorn",
+					},
+				},
+			},
+			newValues: &apiextensionsv1.JSON{
+				Raw: []byte(`{"global": {"ironicIP": "147.28.230.105"}}`),
+			},
+			expectedValues: []byte(`{"global":{"ironicIP":"147.28.230.105"},"metal3-mariadb":{"persistence":{"storageClass":"longhorn"}}}`),
+		},
+		{
+			name:            "Invalid installed values string",
+			installedValues: "{",
+			expectedErr:     "unmarshaling installed chart values: unexpected end of JSON input",
+		},
+		{
+			name:            "Invalid new values",
+			installedValues: "",
+			newValues: &apiextensionsv1.JSON{
+				Raw: []byte(`{`),
+			},
+			expectedErr: "unmarshaling additional chart values: unexpected end of JSON input",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			values, err := mergeHelmValues(test.installedValues, test.newValues)
+			if test.expectedErr != "" {
+				require.Error(t, err)
+				assert.EqualError(t, err, test.expectedErr)
+				assert.Nil(t, values)
+			} else {
+				require.NoError(t, err)
+				assert.Equal(t, string(test.expectedValues), string(values))
+			}
+		})
+	}
+}

--- a/internal/controller/helm_test.go
+++ b/internal/controller/helm_test.go
@@ -9,6 +9,73 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func Test_MergeMaps(t *testing.T) {
+	tests := []struct {
+		name   string
+		m1     map[string]any
+		m2     map[string]any
+		result map[string]any
+	}{
+		{
+			name:   "empty maps",
+			m1:     map[string]any{},
+			m2:     map[string]any{},
+			result: map[string]any{},
+		},
+		{
+			name: "non-empty first map, empty second map",
+			m1: map[string]any{
+				"a": 1,
+			},
+			m2: map[string]any{},
+			result: map[string]any{
+				"a": 1,
+			},
+		},
+		{
+			name: "empty first map, non-empty second map",
+			m1:   map[string]any{},
+			m2: map[string]any{
+				"b": 5,
+			},
+			result: map[string]any{
+				"b": 5,
+			},
+		},
+		{
+			name: "non-empty first map, non-empty second map",
+			m1: map[string]any{
+				"a": map[string]any{
+					"a1": 1,
+					"a2": 5,
+				},
+				"b": "five",
+			},
+			m2: map[string]any{
+				"a": map[string]any{
+					"a1": 100,
+				},
+				"c": 777,
+			},
+			result: map[string]any{
+				"a": map[string]any{
+					"a1": 100,
+					"a2": 5,
+				},
+				"b": "five",
+				"c": 777,
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			result := mergeMaps(test.m1, test.m2)
+			assert.Equal(t, test.result, result)
+		})
+	}
+}
+
 func Test_MergeHelmValues(t *testing.T) {
 	installedValuesStr := `{
   "global": {


### PR DESCRIPTION
- Adds support for additional Helm values in the ReleaseManifest custom resource
- Adds support for additional Helm values in the UpgradePlan custom resource
- User supplied values (via UpgradePlan spec) have higher priority than platform supplied values (via ReleaseManifest spec)