### PR TITLE
Replace dots with "-" in K8s SUC Plan naming

### DIFF
--- a/internal/upgrade/kubernetes.go
+++ b/internal/upgrade/kubernetes.go
@@ -15,7 +15,8 @@ const (
 )
 
 func kubernetesPlanName(typeKey, version string) string {
-	return fmt.Sprintf("%s-%s", typeKey, strings.ReplaceAll(version, "+", "-"))
+	versionReplacer := strings.NewReplacer(".", "-", "+", "-")
+	return fmt.Sprintf("%s-%s", typeKey, versionReplacer.Replace(version))
 }
 
 func kubernetesUpgradeImage(version string) string {


### PR DESCRIPTION
SUC through the following warning for K8s SUC Plans:
```bash
W0823 13:20:39.497039       1 warnings.go:70] metadata.name: this is used in Pod names and hostnames, which can result in surprising behavior; a DNS label is recommended: [must not contain dots]
```

This was caused, because K8s SUC Plans had dots in their names => SUC created Pod with dots in their name.

This PR suggest a fix for this problem, where we replace "." with "-".

SUC Plan naming before:
```bash
cp1rke2:~/upgrade-controller # k get plans
NAME                           IMAGE                                 CHANNEL   VERSION
control-plane-v1.28.9-rke2r1   rancher/rke2-upgrade                            v1.28.9+rke2r1
workers-v1.28.9-rke2r1         rancher/rke2-upgrade                            v1.28.9+rke2r1
```

SUC Plan naming with suggested approach:
```bash
cp1rke2:~/upgrade-controller # k get plans
NAME                           IMAGE                                 CHANNEL   VERSION
control-plane-v1-28-9-rke2r1   rancher/rke2-upgrade                            v1.28.9+rke2r1
workers-v1-28-9-rke2r1         rancher/rke2-upgrade                            v1.28.9+rke2r1
```