### PR TITLE
Use yaml package for (un)marshaling custom values

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/onsi/gomega v1.34.2
 	github.com/rancher/system-upgrade-controller/pkg/apis v0.0.0-20240612205712-57605e3390c0
 	github.com/stretchr/testify v1.9.0
+	gopkg.in/yaml.v3 v3.0.1
 	helm.sh/helm/v3 v3.15.4
 	k8s.io/api v0.31.0
 	k8s.io/apiextensions-apiserver v0.31.0
@@ -90,7 +91,6 @@ require (
 	gopkg.in/evanphx/json-patch.v4 v4.12.0 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
-	gopkg.in/yaml.v3 v3.0.1 // indirect
 	k8s.io/klog/v2 v2.130.1 // indirect
 	k8s.io/kube-openapi v0.0.0-20240228011516-70dd3763d340 // indirect
 	k8s.io/utils v0.0.0-20240711033017-18e509b52bc8 // indirect

--- a/internal/controller/helm.go
+++ b/internal/controller/helm.go
@@ -11,6 +11,8 @@ import (
 	lifecyclev1alpha1 "github.com/suse-edge/upgrade-controller/api/v1alpha1"
 	"github.com/suse-edge/upgrade-controller/internal/upgrade"
 
+	"gopkg.in/yaml.v3"
+
 	helmcattlev1 "github.com/k3s-io/helm-controller/pkg/apis/helm.cattle.io/v1"
 	helmrelease "helm.sh/helm/v3/pkg/release"
 	helmutil "helm.sh/helm/v3/pkg/releaseutil"
@@ -150,7 +152,7 @@ func mergeHelmValues(installedValues any, releaseValues, userValues *apiextensio
 	switch installed := installedValues.(type) {
 	case string:
 		if installed != "" {
-			if err := json.Unmarshal([]byte(installed), &values); err != nil {
+			if err := yaml.Unmarshal([]byte(installed), &values); err != nil {
 				return nil, fmt.Errorf("unmarshaling installed chart values: %w", err)
 			}
 		}
@@ -186,7 +188,7 @@ func mergeHelmValues(installedValues any, releaseValues, userValues *apiextensio
 		return nil, nil
 	}
 
-	v, err := json.Marshal(values)
+	v, err := yaml.Marshal(values)
 	if err != nil {
 		return nil, fmt.Errorf("marshaling chart values: %w", err)
 	}


### PR DESCRIPTION
- Moves to YAML unmarshaling from Helm chart values coming from HelmChart resource
- Keeps JSON unmarshaling from ReleaseManifest resource due to the `apiextensionsv1.JSON` values