### PR TITLE
Add tests for internal/upgrade package

### DIFF
--- a/internal/controller/release_manifest.go
+++ b/internal/controller/release_manifest.go
@@ -34,7 +34,10 @@ func (r *UpgradePlanReconciler) retrieveReleaseManifest(ctx context.Context, upg
 
 func (r *UpgradePlanReconciler) createReleaseManifest(ctx context.Context, upgradePlan *lifecyclev1alpha1.UpgradePlan) error {
 	annotations := upgrade.PlanIdentifierAnnotations(upgradePlan.Name, upgradePlan.Namespace)
-	job := upgrade.ReleaseManifestInstallJob(r.ReleaseManifestImage, upgradePlan.Spec.ReleaseVersion, r.ServiceAccount, upgradePlan.Namespace, annotations)
+	job, err := upgrade.ReleaseManifestInstallJob(r.ReleaseManifestImage, upgradePlan.Spec.ReleaseVersion, r.ServiceAccount, upgradePlan.Namespace, annotations)
+	if err != nil {
+		return err
+	}
 
 	// Retry the creation since a previously failed job could be in the process of deletion due to TTL
 	return retry.OnError(wait.Backoff{Steps: 5, Duration: 500 * time.Millisecond},

--- a/internal/upgrade/base_test.go
+++ b/internal/upgrade/base_test.go
@@ -1,0 +1,50 @@
+package upgrade
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"k8s.io/utils/ptr"
+)
+
+func TestPlanIdentifierAnnotations(t *testing.T) {
+	annotations := PlanIdentifierAnnotations("upgrade-plan-1", "upgrade-controller-system")
+	require.Len(t, annotations, 2)
+
+	assert.Equal(t, "upgrade-plan-1", annotations["lifecycle.suse.com/upgrade-plan-name"])
+	assert.Equal(t, "upgrade-controller-system", annotations["lifecycle.suse.com/upgrade-plan-namespace"])
+}
+
+func TestBaseUpgradePlan_DrainEnabled(t *testing.T) {
+	upgradePlan := baseUpgradePlan("upgrade-plan-1", false, nil)
+
+	assert.Equal(t, "Plan", upgradePlan.TypeMeta.Kind)
+	assert.Equal(t, "upgrade.cattle.io/v1", upgradePlan.TypeMeta.APIVersion)
+
+	assert.Equal(t, "upgrade-plan-1", upgradePlan.ObjectMeta.Name)
+	assert.Equal(t, "cattle-system", upgradePlan.ObjectMeta.Namespace)
+	assert.Nil(t, upgradePlan.ObjectMeta.Annotations)
+
+	assert.Equal(t, "system-upgrade-controller", upgradePlan.Spec.ServiceAccountName)
+	assert.Nil(t, upgradePlan.Spec.Drain)
+}
+
+func TestBaseUpgradePlan_DrainDisabled(t *testing.T) {
+	upgradePlan := baseUpgradePlan("upgrade-plan-1", true, nil)
+
+	assert.Equal(t, "Plan", upgradePlan.TypeMeta.Kind)
+	assert.Equal(t, "upgrade.cattle.io/v1", upgradePlan.TypeMeta.APIVersion)
+
+	assert.Equal(t, "upgrade-plan-1", upgradePlan.ObjectMeta.Name)
+	assert.Equal(t, "cattle-system", upgradePlan.ObjectMeta.Namespace)
+	assert.Nil(t, upgradePlan.ObjectMeta.Annotations)
+
+	assert.Equal(t, "system-upgrade-controller", upgradePlan.Spec.ServiceAccountName)
+	require.NotNil(t, upgradePlan.Spec.Drain)
+	assert.True(t, upgradePlan.Spec.Drain.Force)
+	assert.Equal(t, ptr.To(true), upgradePlan.Spec.Drain.DeleteEmptydirData)
+	assert.Equal(t, ptr.To(true), upgradePlan.Spec.Drain.IgnoreDaemonSets)
+	assert.Equal(t, ptr.To(15*time.Minute), upgradePlan.Spec.Drain.Timeout)
+}

--- a/internal/upgrade/base_test.go
+++ b/internal/upgrade/base_test.go
@@ -17,6 +17,16 @@ func TestPlanIdentifierAnnotations(t *testing.T) {
 	assert.Equal(t, "upgrade-controller-system", annotations["lifecycle.suse.com/upgrade-plan-namespace"])
 }
 
+func TestGenerateSuffix(t *testing.T) {
+	suffix1, err := GenerateSuffix()
+	require.NoError(t, err)
+
+	suffix2, err := GenerateSuffix()
+	require.NoError(t, err)
+
+	assert.NotEqual(t, suffix1, suffix2)
+}
+
 func TestBaseUpgradePlan_DrainEnabled(t *testing.T) {
 	upgradePlan := baseUpgradePlan("upgrade-plan-1", false, nil)
 

--- a/internal/upgrade/helm_test.go
+++ b/internal/upgrade/helm_test.go
@@ -1,0 +1,32 @@
+package upgrade
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestHelmChartState_FormattedMessage(t *testing.T) {
+	const chart = "metal3"
+
+	state := ChartStateUnknown
+	assert.Equal(t, "State of chart metal3 is unknown", state.FormattedMessage(chart))
+
+	state = ChartStateNotInstalled
+	assert.Equal(t, "Chart metal3 is not installed", state.FormattedMessage(chart))
+
+	state = ChartStateVersionAlreadyInstalled
+	assert.Equal(t, "Specified version of chart metal3 is already installed", state.FormattedMessage(chart))
+
+	state = ChartStateInProgress
+	assert.Equal(t, "Chart metal3 upgrade is in progress", state.FormattedMessage(chart))
+
+	state = ChartStateFailed
+	assert.Equal(t, "Chart metal3 upgrade failed", state.FormattedMessage(chart))
+
+	state = ChartStateSucceeded
+	assert.Equal(t, "Chart metal3 upgrade succeeded", state.FormattedMessage(chart))
+
+	state = 99 // non-existing
+	assert.Equal(t, "", state.FormattedMessage(chart))
+}

--- a/internal/upgrade/kubernetes_test.go
+++ b/internal/upgrade/kubernetes_test.go
@@ -161,13 +161,17 @@ func TestKubernetesWorkerPlan_RKE2(t *testing.T) {
 	assert.EqualValues(t, "NotIn", matchExpression.Operator)
 	assert.Equal(t, []string{"true"}, matchExpression.Values)
 
-	require.NotNil(t, upgradePlan.Spec.Prepare)
-	assert.Equal(t, "rancher/rke2-upgrade", upgradePlan.Spec.Prepare.Image)
-	assert.Equal(t, []string{"prepare", "control-plane-v1-30-2-rke2r1-abcdef"}, upgradePlan.Spec.Prepare.Args)
+	prepareContainer := upgradePlan.Spec.Prepare
+	require.NotNil(t, prepareContainer)
+	assert.Equal(t, "rancher/rke2-upgrade", prepareContainer.Image)
+	assert.Empty(t, prepareContainer.Command)
+	assert.Equal(t, []string{"prepare", "control-plane-v1-30-2-rke2r1-abcdef"}, prepareContainer.Args)
 
-	require.NotNil(t, upgradePlan.Spec.Upgrade)
-	assert.Equal(t, "rancher/rke2-upgrade", upgradePlan.Spec.Upgrade.Image)
-	assert.Nil(t, upgradePlan.Spec.Upgrade.Args)
+	upgradeContainer := upgradePlan.Spec.Upgrade
+	require.NotNil(t, upgradeContainer)
+	assert.Equal(t, "rancher/rke2-upgrade", upgradeContainer.Image)
+	assert.Empty(t, upgradeContainer.Command)
+	assert.Empty(t, upgradeContainer.Args)
 
 	assert.Equal(t, version, upgradePlan.Spec.Version)
 	assert.EqualValues(t, 2, upgradePlan.Spec.Concurrency)
@@ -206,13 +210,17 @@ func TestKubernetesWorkerPlan_K3s(t *testing.T) {
 	assert.EqualValues(t, "NotIn", matchExpression.Operator)
 	assert.Equal(t, []string{"true"}, matchExpression.Values)
 
-	require.NotNil(t, upgradePlan.Spec.Prepare)
-	assert.Equal(t, "rancher/k3s-upgrade", upgradePlan.Spec.Prepare.Image)
-	assert.Equal(t, []string{"prepare", "control-plane-v1-30-2-k3s1-abcdef"}, upgradePlan.Spec.Prepare.Args)
+	prepareContainer := upgradePlan.Spec.Prepare
+	require.NotNil(t, prepareContainer)
+	assert.Equal(t, "rancher/k3s-upgrade", prepareContainer.Image)
+	assert.Empty(t, prepareContainer.Command)
+	assert.Equal(t, []string{"prepare", "control-plane-v1-30-2-k3s1-abcdef"}, prepareContainer.Args)
 
-	require.NotNil(t, upgradePlan.Spec.Upgrade)
-	assert.Equal(t, "rancher/k3s-upgrade", upgradePlan.Spec.Upgrade.Image)
-	assert.Nil(t, upgradePlan.Spec.Upgrade.Args)
+	upgradeContainer := upgradePlan.Spec.Upgrade
+	require.NotNil(t, upgradeContainer)
+	assert.Equal(t, "rancher/k3s-upgrade", upgradeContainer.Image)
+	assert.Empty(t, upgradeContainer.Command)
+	assert.Empty(t, upgradeContainer.Args)
 
 	assert.Equal(t, version, upgradePlan.Spec.Version)
 	assert.EqualValues(t, 2, upgradePlan.Spec.Concurrency)

--- a/internal/upgrade/kubernetes_test.go
+++ b/internal/upgrade/kubernetes_test.go
@@ -1,0 +1,225 @@
+package upgrade
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+)
+
+func TestKubernetesControlPlanePlan_RKE2(t *testing.T) {
+	nameSuffix := "abcdef"
+	version := "v1.30.2+rke2r1"
+	annotations := map[string]string{
+		"lifecycle.suse.com/x": "z",
+	}
+
+	upgradePlan := KubernetesControlPlanePlan(nameSuffix, version, false, annotations)
+	require.NotNil(t, upgradePlan)
+
+	assert.Equal(t, "Plan", upgradePlan.TypeMeta.Kind)
+	assert.Equal(t, "upgrade.cattle.io/v1", upgradePlan.TypeMeta.APIVersion)
+
+	assert.Equal(t, "control-plane-v1-30-2-rke2r1-abcdef", upgradePlan.ObjectMeta.Name)
+	assert.Equal(t, "cattle-system", upgradePlan.ObjectMeta.Namespace)
+	assert.Equal(t, annotations, upgradePlan.ObjectMeta.Annotations)
+	require.Len(t, upgradePlan.ObjectMeta.Labels, 1)
+	assert.Equal(t, "control-plane", upgradePlan.ObjectMeta.Labels["k8s-upgrade"])
+
+	require.Len(t, upgradePlan.Spec.NodeSelector.MatchLabels, 0)
+	require.Len(t, upgradePlan.Spec.NodeSelector.MatchExpressions, 1)
+
+	matchExpression := upgradePlan.Spec.NodeSelector.MatchExpressions[0]
+	assert.Equal(t, "node-role.kubernetes.io/control-plane", matchExpression.Key)
+	assert.EqualValues(t, "In", matchExpression.Operator)
+	assert.Equal(t, []string{"true"}, matchExpression.Values)
+
+	require.Nil(t, upgradePlan.Spec.Prepare)
+
+	require.NotNil(t, upgradePlan.Spec.Upgrade)
+	assert.Equal(t, "rancher/rke2-upgrade", upgradePlan.Spec.Upgrade.Image)
+	assert.Nil(t, upgradePlan.Spec.Upgrade.Args)
+
+	assert.Equal(t, version, upgradePlan.Spec.Version)
+	assert.EqualValues(t, 1, upgradePlan.Spec.Concurrency)
+	assert.True(t, upgradePlan.Spec.Cordon)
+
+	assert.Equal(t, "system-upgrade-controller", upgradePlan.Spec.ServiceAccountName)
+	assert.Nil(t, upgradePlan.Spec.Drain)
+
+	tolerations := []corev1.Toleration{
+		{
+			Key:      "CriticalAddonsOnly",
+			Operator: "Equal",
+			Value:    "true",
+			Effect:   "NoExecute",
+		},
+		{
+			Key:      ControlPlaneLabel,
+			Operator: "Equal",
+			Value:    "",
+			Effect:   "NoSchedule",
+		},
+		{
+			Key:      "node-role.kubernetes.io/etcd",
+			Operator: "Equal",
+			Value:    "",
+			Effect:   "NoExecute",
+		},
+	}
+	assert.Equal(t, tolerations, upgradePlan.Spec.Tolerations)
+}
+
+func TestKubernetesControlPlanePlan_K3s(t *testing.T) {
+	nameSuffix := "abcdef"
+	version := "v1.30.2+k3s1"
+	annotations := map[string]string{
+		"lifecycle.suse.com/x": "z",
+	}
+
+	upgradePlan := KubernetesControlPlanePlan(nameSuffix, version, false, annotations)
+	require.NotNil(t, upgradePlan)
+
+	assert.Equal(t, "Plan", upgradePlan.TypeMeta.Kind)
+	assert.Equal(t, "upgrade.cattle.io/v1", upgradePlan.TypeMeta.APIVersion)
+
+	assert.Equal(t, "control-plane-v1-30-2-k3s1-abcdef", upgradePlan.ObjectMeta.Name)
+	assert.Equal(t, "cattle-system", upgradePlan.ObjectMeta.Namespace)
+	assert.Equal(t, annotations, upgradePlan.ObjectMeta.Annotations)
+	require.Len(t, upgradePlan.ObjectMeta.Labels, 1)
+	assert.Equal(t, "control-plane", upgradePlan.ObjectMeta.Labels["k8s-upgrade"])
+
+	require.Len(t, upgradePlan.Spec.NodeSelector.MatchLabels, 0)
+	require.Len(t, upgradePlan.Spec.NodeSelector.MatchExpressions, 1)
+
+	matchExpression := upgradePlan.Spec.NodeSelector.MatchExpressions[0]
+	assert.Equal(t, "node-role.kubernetes.io/control-plane", matchExpression.Key)
+	assert.EqualValues(t, "In", matchExpression.Operator)
+	assert.Equal(t, []string{"true"}, matchExpression.Values)
+
+	require.Nil(t, upgradePlan.Spec.Prepare)
+
+	require.NotNil(t, upgradePlan.Spec.Upgrade)
+	assert.Equal(t, "rancher/k3s-upgrade", upgradePlan.Spec.Upgrade.Image)
+	assert.Nil(t, upgradePlan.Spec.Upgrade.Args)
+
+	assert.Equal(t, version, upgradePlan.Spec.Version)
+	assert.EqualValues(t, 1, upgradePlan.Spec.Concurrency)
+	assert.True(t, upgradePlan.Spec.Cordon)
+
+	assert.Equal(t, "system-upgrade-controller", upgradePlan.Spec.ServiceAccountName)
+	assert.Nil(t, upgradePlan.Spec.Drain)
+
+	tolerations := []corev1.Toleration{
+		{
+			Key:      "CriticalAddonsOnly",
+			Operator: "Equal",
+			Value:    "true",
+			Effect:   "NoExecute",
+		},
+		{
+			Key:      ControlPlaneLabel,
+			Operator: "Equal",
+			Value:    "",
+			Effect:   "NoSchedule",
+		},
+		{
+			Key:      "node-role.kubernetes.io/etcd",
+			Operator: "Equal",
+			Value:    "",
+			Effect:   "NoExecute",
+		},
+	}
+	assert.Equal(t, tolerations, upgradePlan.Spec.Tolerations)
+}
+
+func TestKubernetesWorkerPlan_RKE2(t *testing.T) {
+	nameSuffix := "abcdef"
+	version := "v1.30.2+rke2r1"
+	annotations := map[string]string{
+		"lifecycle.suse.com/x": "z",
+	}
+
+	upgradePlan := KubernetesWorkerPlan(nameSuffix, version, false, annotations)
+	require.NotNil(t, upgradePlan)
+
+	assert.Equal(t, "Plan", upgradePlan.TypeMeta.Kind)
+	assert.Equal(t, "upgrade.cattle.io/v1", upgradePlan.TypeMeta.APIVersion)
+
+	assert.Equal(t, "workers-v1-30-2-rke2r1-abcdef", upgradePlan.ObjectMeta.Name)
+	assert.Equal(t, "cattle-system", upgradePlan.ObjectMeta.Namespace)
+	assert.Equal(t, annotations, upgradePlan.ObjectMeta.Annotations)
+	require.Len(t, upgradePlan.ObjectMeta.Labels, 1)
+	assert.Equal(t, "worker", upgradePlan.ObjectMeta.Labels["k8s-upgrade"])
+
+	require.Len(t, upgradePlan.Spec.NodeSelector.MatchLabels, 0)
+	require.Len(t, upgradePlan.Spec.NodeSelector.MatchExpressions, 1)
+
+	matchExpression := upgradePlan.Spec.NodeSelector.MatchExpressions[0]
+	assert.Equal(t, "node-role.kubernetes.io/control-plane", matchExpression.Key)
+	assert.EqualValues(t, "NotIn", matchExpression.Operator)
+	assert.Equal(t, []string{"true"}, matchExpression.Values)
+
+	require.NotNil(t, upgradePlan.Spec.Prepare)
+	assert.Equal(t, "rancher/rke2-upgrade", upgradePlan.Spec.Prepare.Image)
+	assert.Equal(t, []string{"prepare", "control-plane-v1-30-2-rke2r1-abcdef"}, upgradePlan.Spec.Prepare.Args)
+
+	require.NotNil(t, upgradePlan.Spec.Upgrade)
+	assert.Equal(t, "rancher/rke2-upgrade", upgradePlan.Spec.Upgrade.Image)
+	assert.Nil(t, upgradePlan.Spec.Upgrade.Args)
+
+	assert.Equal(t, version, upgradePlan.Spec.Version)
+	assert.EqualValues(t, 2, upgradePlan.Spec.Concurrency)
+	assert.True(t, upgradePlan.Spec.Cordon)
+
+	assert.Equal(t, "system-upgrade-controller", upgradePlan.Spec.ServiceAccountName)
+	assert.Nil(t, upgradePlan.Spec.Drain)
+
+	assert.Len(t, upgradePlan.Spec.Tolerations, 0)
+}
+
+func TestKubernetesWorkerPlan_K3s(t *testing.T) {
+	nameSuffix := "abcdef"
+	version := "v1.30.2+k3s1"
+	annotations := map[string]string{
+		"lifecycle.suse.com/x": "z",
+	}
+
+	upgradePlan := KubernetesWorkerPlan(nameSuffix, version, false, annotations)
+	require.NotNil(t, upgradePlan)
+
+	assert.Equal(t, "Plan", upgradePlan.TypeMeta.Kind)
+	assert.Equal(t, "upgrade.cattle.io/v1", upgradePlan.TypeMeta.APIVersion)
+
+	assert.Equal(t, "workers-v1-30-2-k3s1-abcdef", upgradePlan.ObjectMeta.Name)
+	assert.Equal(t, "cattle-system", upgradePlan.ObjectMeta.Namespace)
+	assert.Equal(t, annotations, upgradePlan.ObjectMeta.Annotations)
+	require.Len(t, upgradePlan.ObjectMeta.Labels, 1)
+	assert.Equal(t, "worker", upgradePlan.ObjectMeta.Labels["k8s-upgrade"])
+
+	require.Len(t, upgradePlan.Spec.NodeSelector.MatchLabels, 0)
+	require.Len(t, upgradePlan.Spec.NodeSelector.MatchExpressions, 1)
+
+	matchExpression := upgradePlan.Spec.NodeSelector.MatchExpressions[0]
+	assert.Equal(t, "node-role.kubernetes.io/control-plane", matchExpression.Key)
+	assert.EqualValues(t, "NotIn", matchExpression.Operator)
+	assert.Equal(t, []string{"true"}, matchExpression.Values)
+
+	require.NotNil(t, upgradePlan.Spec.Prepare)
+	assert.Equal(t, "rancher/k3s-upgrade", upgradePlan.Spec.Prepare.Image)
+	assert.Equal(t, []string{"prepare", "control-plane-v1-30-2-k3s1-abcdef"}, upgradePlan.Spec.Prepare.Args)
+
+	require.NotNil(t, upgradePlan.Spec.Upgrade)
+	assert.Equal(t, "rancher/k3s-upgrade", upgradePlan.Spec.Upgrade.Image)
+	assert.Nil(t, upgradePlan.Spec.Upgrade.Args)
+
+	assert.Equal(t, version, upgradePlan.Spec.Version)
+	assert.EqualValues(t, 2, upgradePlan.Spec.Concurrency)
+	assert.True(t, upgradePlan.Spec.Cordon)
+
+	assert.Equal(t, "system-upgrade-controller", upgradePlan.Spec.ServiceAccountName)
+	assert.Nil(t, upgradePlan.Spec.Drain)
+
+	assert.Len(t, upgradePlan.Spec.Tolerations, 0)
+}

--- a/internal/upgrade/kubernetes_test.go
+++ b/internal/upgrade/kubernetes_test.go
@@ -9,13 +9,12 @@ import (
 )
 
 func TestKubernetesControlPlanePlan_RKE2(t *testing.T) {
-	nameSuffix := "abcdef"
 	version := "v1.30.2+rke2r1"
 	annotations := map[string]string{
 		"lifecycle.suse.com/x": "z",
 	}
 
-	upgradePlan := KubernetesControlPlanePlan(nameSuffix, version, false, annotations)
+	upgradePlan := KubernetesControlPlanePlan(planNameSuffix, version, false, annotations)
 	require.NotNil(t, upgradePlan)
 
 	assert.Equal(t, "Plan", upgradePlan.TypeMeta.Kind)
@@ -72,13 +71,12 @@ func TestKubernetesControlPlanePlan_RKE2(t *testing.T) {
 }
 
 func TestKubernetesControlPlanePlan_K3s(t *testing.T) {
-	nameSuffix := "abcdef"
 	version := "v1.30.2+k3s1"
 	annotations := map[string]string{
 		"lifecycle.suse.com/x": "z",
 	}
 
-	upgradePlan := KubernetesControlPlanePlan(nameSuffix, version, false, annotations)
+	upgradePlan := KubernetesControlPlanePlan(planNameSuffix, version, false, annotations)
 	require.NotNil(t, upgradePlan)
 
 	assert.Equal(t, "Plan", upgradePlan.TypeMeta.Kind)
@@ -135,13 +133,12 @@ func TestKubernetesControlPlanePlan_K3s(t *testing.T) {
 }
 
 func TestKubernetesWorkerPlan_RKE2(t *testing.T) {
-	nameSuffix := "abcdef"
 	version := "v1.30.2+rke2r1"
 	annotations := map[string]string{
 		"lifecycle.suse.com/x": "z",
 	}
 
-	upgradePlan := KubernetesWorkerPlan(nameSuffix, version, false, annotations)
+	upgradePlan := KubernetesWorkerPlan(planNameSuffix, version, false, annotations)
 	require.NotNil(t, upgradePlan)
 
 	assert.Equal(t, "Plan", upgradePlan.TypeMeta.Kind)
@@ -184,13 +181,12 @@ func TestKubernetesWorkerPlan_RKE2(t *testing.T) {
 }
 
 func TestKubernetesWorkerPlan_K3s(t *testing.T) {
-	nameSuffix := "abcdef"
 	version := "v1.30.2+k3s1"
 	annotations := map[string]string{
 		"lifecycle.suse.com/x": "z",
 	}
 
-	upgradePlan := KubernetesWorkerPlan(nameSuffix, version, false, annotations)
+	upgradePlan := KubernetesWorkerPlan(planNameSuffix, version, false, annotations)
 	require.NotNil(t, upgradePlan)
 
 	assert.Equal(t, "Plan", upgradePlan.TypeMeta.Kind)

--- a/internal/upgrade/os_test.go
+++ b/internal/upgrade/os_test.go
@@ -9,8 +9,12 @@ import (
 	corev1 "k8s.io/api/core/v1"
 )
 
+const (
+	planNameSuffix = "abcdef"
+	releaseVersion = "3.1.0"
+)
+
 func TestOSUpgradeSecret(t *testing.T) {
-	nameSuffix := "abcdef"
 	os := &lifecyclev1alpha1.OperatingSystem{
 		Version:     "6.0",
 		ZypperID:    "SL-Micro",
@@ -21,7 +25,7 @@ func TestOSUpgradeSecret(t *testing.T) {
 		"lifecycle.suse.com/x": "z",
 	}
 
-	secret, err := OSUpgradeSecret(nameSuffix, os, annotations)
+	secret, err := OSUpgradeSecret(planNameSuffix, os, annotations)
 	require.NoError(t, err)
 
 	assert.Equal(t, "Secret", secret.TypeMeta.Kind)
@@ -43,8 +47,6 @@ func TestOSUpgradeSecret(t *testing.T) {
 }
 
 func TestOSControlPlanePlan(t *testing.T) {
-	nameSuffix := "abcdef"
-	releaseVersion := "3.1.0"
 	secretName := "some-secret"
 	os := &lifecyclev1alpha1.OperatingSystem{
 		Version:  "6.0",
@@ -54,7 +56,7 @@ func TestOSControlPlanePlan(t *testing.T) {
 		"lifecycle.suse.com/x": "z",
 	}
 
-	upgradePlan := OSControlPlanePlan(nameSuffix, releaseVersion, secretName, os, false, annotations)
+	upgradePlan := OSControlPlanePlan(planNameSuffix, releaseVersion, secretName, os, false, annotations)
 	require.NotNil(t, upgradePlan)
 
 	assert.Equal(t, "Plan", upgradePlan.TypeMeta.Kind)
@@ -114,8 +116,6 @@ func TestOSControlPlanePlan(t *testing.T) {
 }
 
 func TestOSWorkerPlan(t *testing.T) {
-	nameSuffix := "abcdef"
-	releaseVersion := "3.1.0"
 	secretName := "some-secret"
 	os := &lifecyclev1alpha1.OperatingSystem{
 		Version:  "6.0",
@@ -125,7 +125,7 @@ func TestOSWorkerPlan(t *testing.T) {
 		"lifecycle.suse.com/x": "z",
 	}
 
-	upgradePlan := OSWorkerPlan(nameSuffix, releaseVersion, secretName, os, false, annotations)
+	upgradePlan := OSWorkerPlan(planNameSuffix, releaseVersion, secretName, os, false, annotations)
 	require.NotNil(t, upgradePlan)
 
 	assert.Equal(t, "Plan", upgradePlan.TypeMeta.Kind)

--- a/internal/upgrade/os_test.go
+++ b/internal/upgrade/os_test.go
@@ -1,0 +1,165 @@
+package upgrade
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	lifecyclev1alpha1 "github.com/suse-edge/upgrade-controller/api/v1alpha1"
+	corev1 "k8s.io/api/core/v1"
+)
+
+func TestOSUpgradeSecret(t *testing.T) {
+	nameSuffix := "abcdef"
+	os := &lifecyclev1alpha1.OperatingSystem{
+		Version:     "6.0",
+		ZypperID:    "SL-Micro",
+		CPEScheme:   "some-cpe-scheme",
+		RepoGPGPath: "some-gpg-path",
+	}
+	annotations := map[string]string{
+		"lifecycle.suse.com/x": "z",
+	}
+
+	secret, err := OSUpgradeSecret(nameSuffix, os, annotations)
+	require.NoError(t, err)
+
+	assert.Equal(t, "Secret", secret.TypeMeta.Kind)
+	assert.Equal(t, "v1", secret.TypeMeta.APIVersion)
+
+	assert.Equal(t, "os-upgrade-secret-sl-micro-6-0-abcdef", secret.ObjectMeta.Name)
+	assert.Equal(t, "cattle-system", secret.ObjectMeta.Namespace)
+	assert.Equal(t, annotations, secret.ObjectMeta.Annotations)
+
+	assert.EqualValues(t, "Opaque", secret.Type)
+
+	require.Len(t, secret.StringData, 1)
+	scriptContents := secret.StringData["os-upgrade.sh"]
+	require.NotEmpty(t, scriptContents)
+
+	assert.Contains(t, scriptContents, "RELEASE_CPE=some-cpe-scheme")
+	assert.Contains(t, scriptContents, "/usr/sbin/transactional-update --continue run rpm --import some-gpg-path")
+	assert.Contains(t, scriptContents, "/usr/sbin/transactional-update --continue run zypper migration --non-interactive --product SL-Micro/6.0/${SYSTEM_ARCH} --root /")
+}
+
+func TestOSControlPlanePlan(t *testing.T) {
+	nameSuffix := "abcdef"
+	releaseVersion := "3.1.0"
+	secretName := "some-secret"
+	os := &lifecyclev1alpha1.OperatingSystem{
+		Version:  "6.0",
+		ZypperID: "SL-Micro",
+	}
+	annotations := map[string]string{
+		"lifecycle.suse.com/x": "z",
+	}
+
+	upgradePlan := OSControlPlanePlan(nameSuffix, releaseVersion, secretName, os, false, annotations)
+	require.NotNil(t, upgradePlan)
+
+	assert.Equal(t, "Plan", upgradePlan.TypeMeta.Kind)
+	assert.Equal(t, "upgrade.cattle.io/v1", upgradePlan.TypeMeta.APIVersion)
+
+	assert.Equal(t, "control-plane-sl-micro-6-0-abcdef", upgradePlan.ObjectMeta.Name)
+	assert.Equal(t, "cattle-system", upgradePlan.ObjectMeta.Namespace)
+	assert.Equal(t, annotations, upgradePlan.ObjectMeta.Annotations)
+	require.Len(t, upgradePlan.ObjectMeta.Labels, 1)
+	assert.Equal(t, "control-plane", upgradePlan.ObjectMeta.Labels["os-upgrade"])
+
+	require.Len(t, upgradePlan.Spec.NodeSelector.MatchLabels, 0)
+	require.Len(t, upgradePlan.Spec.NodeSelector.MatchExpressions, 1)
+
+	matchExpression := upgradePlan.Spec.NodeSelector.MatchExpressions[0]
+	assert.Equal(t, "node-role.kubernetes.io/control-plane", matchExpression.Key)
+	assert.EqualValues(t, "In", matchExpression.Operator)
+	assert.Equal(t, []string{"true"}, matchExpression.Values)
+
+	require.Nil(t, upgradePlan.Spec.Prepare)
+
+	upgradeContainer := upgradePlan.Spec.Upgrade
+	require.NotNil(t, upgradeContainer)
+	assert.Equal(t, "registry.suse.com/bci/bci-base:15.5", upgradeContainer.Image)
+	assert.Equal(t, []string{"chroot", "/host"}, upgradeContainer.Command)
+	assert.Equal(t, []string{"sh", "/run/system-upgrade/secrets/some-secret/os-upgrade.sh"}, upgradeContainer.Args)
+
+	assert.Equal(t, "3.1.0", upgradePlan.Spec.Version)
+	assert.EqualValues(t, 1, upgradePlan.Spec.Concurrency)
+	assert.EqualValues(t, 3600, upgradePlan.Spec.JobActiveDeadlineSecs)
+	assert.True(t, upgradePlan.Spec.Cordon)
+
+	assert.Equal(t, "system-upgrade-controller", upgradePlan.Spec.ServiceAccountName)
+	assert.Nil(t, upgradePlan.Spec.Drain)
+
+	tolerations := []corev1.Toleration{
+		{
+			Key:      "CriticalAddonsOnly",
+			Operator: "Equal",
+			Value:    "true",
+			Effect:   "NoExecute",
+		},
+		{
+			Key:      ControlPlaneLabel,
+			Operator: "Equal",
+			Value:    "",
+			Effect:   "NoSchedule",
+		},
+		{
+			Key:      "node-role.kubernetes.io/etcd",
+			Operator: "Equal",
+			Value:    "",
+			Effect:   "NoExecute",
+		},
+	}
+	assert.Equal(t, tolerations, upgradePlan.Spec.Tolerations)
+}
+
+func TestOSWorkerPlan(t *testing.T) {
+	nameSuffix := "abcdef"
+	releaseVersion := "3.1.0"
+	secretName := "some-secret"
+	os := &lifecyclev1alpha1.OperatingSystem{
+		Version:  "6.0",
+		ZypperID: "SL-Micro",
+	}
+	annotations := map[string]string{
+		"lifecycle.suse.com/x": "z",
+	}
+
+	upgradePlan := OSWorkerPlan(nameSuffix, releaseVersion, secretName, os, false, annotations)
+	require.NotNil(t, upgradePlan)
+
+	assert.Equal(t, "Plan", upgradePlan.TypeMeta.Kind)
+	assert.Equal(t, "upgrade.cattle.io/v1", upgradePlan.TypeMeta.APIVersion)
+
+	assert.Equal(t, "workers-sl-micro-6-0-abcdef", upgradePlan.ObjectMeta.Name)
+	assert.Equal(t, "cattle-system", upgradePlan.ObjectMeta.Namespace)
+	assert.Equal(t, annotations, upgradePlan.ObjectMeta.Annotations)
+	require.Len(t, upgradePlan.ObjectMeta.Labels, 1)
+	assert.Equal(t, "worker", upgradePlan.ObjectMeta.Labels["os-upgrade"])
+
+	require.Len(t, upgradePlan.Spec.NodeSelector.MatchLabels, 0)
+	require.Len(t, upgradePlan.Spec.NodeSelector.MatchExpressions, 1)
+
+	matchExpression := upgradePlan.Spec.NodeSelector.MatchExpressions[0]
+	assert.Equal(t, "node-role.kubernetes.io/control-plane", matchExpression.Key)
+	assert.EqualValues(t, "NotIn", matchExpression.Operator)
+	assert.Equal(t, []string{"true"}, matchExpression.Values)
+
+	require.Nil(t, upgradePlan.Spec.Prepare)
+
+	upgradeContainer := upgradePlan.Spec.Upgrade
+	require.NotNil(t, upgradeContainer)
+	assert.Equal(t, "registry.suse.com/bci/bci-base:15.5", upgradeContainer.Image)
+	assert.Equal(t, []string{"chroot", "/host"}, upgradeContainer.Command)
+	assert.Equal(t, []string{"sh", "/run/system-upgrade/secrets/some-secret/os-upgrade.sh"}, upgradeContainer.Args)
+
+	assert.Equal(t, "3.1.0", upgradePlan.Spec.Version)
+	assert.EqualValues(t, 2, upgradePlan.Spec.Concurrency)
+	assert.EqualValues(t, 3600, upgradePlan.Spec.JobActiveDeadlineSecs)
+	assert.True(t, upgradePlan.Spec.Cordon)
+
+	assert.Equal(t, "system-upgrade-controller", upgradePlan.Spec.ServiceAccountName)
+	assert.Nil(t, upgradePlan.Spec.Drain)
+
+	assert.Len(t, upgradePlan.Spec.Tolerations, 0)
+}

--- a/internal/upgrade/release_manifest.go
+++ b/internal/upgrade/release_manifest.go
@@ -9,7 +9,13 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-func ReleaseManifestInstallJob(image, version, serviceAccount, namespace string, annotations map[string]string) *batchv1.Job {
+func ReleaseManifestInstallJob(image, version, serviceAccount, namespace string, annotations map[string]string) (*batchv1.Job, error) {
+	if image == "" {
+		return nil, fmt.Errorf("release manifest image is empty")
+	} else if version == "" {
+		return nil, fmt.Errorf("release manifest version is empty")
+	}
+
 	version = strings.TrimPrefix(version, "v")
 	workloadName := fmt.Sprintf("apply-release-manifest-%s", strings.ReplaceAll(version, ".", "-"))
 	image = fmt.Sprintf("%s:%s", image, version)
@@ -45,5 +51,5 @@ func ReleaseManifestInstallJob(image, version, serviceAccount, namespace string,
 			},
 			TTLSecondsAfterFinished: &ttl,
 		},
-	}
+	}, nil
 }

--- a/internal/upgrade/release_manifest_test.go
+++ b/internal/upgrade/release_manifest_test.go
@@ -1,0 +1,55 @@
+package upgrade
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestReleaseManifestInstallJob(t *testing.T) {
+	imageName := "registry.suse.com/edge/release-manifest"
+	imageVersion := "3.1.0"
+	serviceAccount := "upgrade-controller-sa"
+	namespace := "upgrade-controller-ns"
+	annotations := map[string]string{
+		"lifecycle.suse.com/x": "z",
+	}
+
+	job, err := ReleaseManifestInstallJob(imageName, imageVersion, serviceAccount, namespace, annotations)
+	require.NoError(t, err)
+
+	assert.Equal(t, "batch/v1", job.TypeMeta.APIVersion)
+	assert.Equal(t, "Job", job.TypeMeta.Kind)
+
+	assert.Equal(t, "apply-release-manifest-3-1-0", job.ObjectMeta.Name)
+	assert.Equal(t, "upgrade-controller-ns", job.ObjectMeta.Namespace)
+	require.Len(t, job.ObjectMeta.Annotations, 1)
+	assert.Equal(t, annotations, job.ObjectMeta.Annotations)
+
+	assert.Equal(t, "apply-release-manifest-3-1-0", job.Spec.Template.ObjectMeta.Name)
+	assert.Equal(t, "upgrade-controller-ns", job.Spec.Template.ObjectMeta.Namespace)
+
+	require.Len(t, job.Spec.Template.Spec.Containers, 1)
+
+	containerSpec := job.Spec.Template.Spec.Containers[0]
+	assert.Equal(t, "apply-release-manifest-3-1-0", containerSpec.Name)
+	assert.Equal(t, "registry.suse.com/edge/release-manifest:3.1.0", containerSpec.Image)
+	assert.Equal(t, []string{"apply", "-f", "release_manifest.yaml"}, containerSpec.Args)
+
+	assert.EqualValues(t, "OnFailure", job.Spec.Template.Spec.RestartPolicy)
+	assert.Equal(t, "upgrade-controller-sa", job.Spec.Template.Spec.ServiceAccountName)
+
+	ttl := int32(0)
+	assert.Equal(t, &ttl, job.Spec.TTLSecondsAfterFinished)
+
+	job, err = ReleaseManifestInstallJob("", imageVersion, serviceAccount, namespace, annotations)
+	require.Error(t, err)
+	assert.EqualError(t, err, "release manifest image is empty")
+	assert.Nil(t, job)
+
+	job, err = ReleaseManifestInstallJob(imageName, "", serviceAccount, namespace, annotations)
+	require.Error(t, err)
+	assert.EqualError(t, err, "release manifest version is empty")
+	assert.Nil(t, job)
+}


### PR DESCRIPTION
- Adds unit tests covering the construction of different resources in the upgrade package
- Tests do include a lot of repetition and manual assertions due to the nature of the constantly changing resources