### PR TITLE
Split release manifest applying

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -165,6 +165,8 @@ func main() {
 		Recorder:             mgr.GetEventRecorderFor("upgrade-plan-controller"),
 		ServiceAccount:       serviceAccountName,
 		ReleaseManifestImage: releaseManifestImage,
+		KubectlImage:         "registry.opensuse.org/isv/suse/edge/lifecycle/containerfile/kubectl",
+		KubectlVersion:       "1.30.3",
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "UpgradePlan")
 		os.Exit(1)

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -58,7 +58,11 @@ func init() {
 	// +kubebuilder:scaffold:scheme
 }
 
-const defaultReleaseManifestImage = "registry.opensuse.org/isv/suse/edge/lifecycle/containerfile/suse/release-manifest"
+const (
+	defaultReleaseManifestImage = "registry.opensuse.org/isv/suse/edge/lifecycle/containerfile/suse/release-manifest"
+	defaultKubectlImage         = "registry.opensuse.org/isv/suse/edge/lifecycle/containerfile/kubectl"
+	defaultKubectlVersion       = "1.30.3"
+)
 
 func main() {
 	var metricsAddr string
@@ -68,6 +72,8 @@ func main() {
 	var enableHTTP2 bool
 	var watchNamespace string
 	var releaseManifestImage string
+	var kubectlImage string
+	var kubectlVersion string
 	var serviceAccountName string
 
 	flag.StringVar(&metricsAddr, "metrics-bind-address", "0", "The address the metric endpoint binds to. "+
@@ -84,6 +90,10 @@ func main() {
 		"Namespace that the controller watches to reconcile resources.")
 	flag.StringVar(&releaseManifestImage, "release-manifest-image", os.Getenv("RELEASE_MANIFEST_IMAGE"),
 		"Source of release manifest container images")
+	flag.StringVar(&kubectlImage, "kubectl-image", os.Getenv("KUBECTL_IMAGE"),
+		"Source of the kubectl container image")
+	flag.StringVar(&kubectlVersion, "kubectl-version", os.Getenv("KUBECTL_VERSION"),
+		"Version of the kubectl container image")
 	flag.StringVar(&serviceAccountName, "service-account-name", os.Getenv("SERVICE_ACCOUNT_NAME"),
 		"Service account of the controller")
 
@@ -127,6 +137,12 @@ func main() {
 	if releaseManifestImage == "" {
 		releaseManifestImage = defaultReleaseManifestImage
 	}
+	if kubectlImage == "" {
+		kubectlImage = defaultKubectlImage
+	}
+	if kubectlVersion == "" {
+		kubectlVersion = defaultKubectlVersion
+	}
 
 	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), ctrl.Options{
 		Scheme: scheme,
@@ -165,8 +181,8 @@ func main() {
 		Recorder:             mgr.GetEventRecorderFor("upgrade-plan-controller"),
 		ServiceAccount:       serviceAccountName,
 		ReleaseManifestImage: releaseManifestImage,
-		KubectlImage:         "registry.opensuse.org/isv/suse/edge/lifecycle/containerfile/kubectl",
-		KubectlVersion:       "1.30.3",
+		KubectlImage:         kubectlImage,
+		KubectlVersion:       kubectlVersion,
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "UpgradePlan")
 		os.Exit(1)

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -181,8 +181,10 @@ func main() {
 		Recorder:             mgr.GetEventRecorderFor("upgrade-plan-controller"),
 		ServiceAccount:       serviceAccountName,
 		ReleaseManifestImage: releaseManifestImage,
-		KubectlImage:         kubectlImage,
-		KubectlVersion:       kubectlVersion,
+		Kubectl: upgrade.ContainerImage{
+			Name:    kubectlImage,
+			Version: kubectlVersion,
+		},
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "UpgradePlan")
 		os.Exit(1)

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -71,7 +71,7 @@ spec:
               fieldRef:
                 fieldPath: metadata.namespace
           - name: RELEASE_MANIFEST_IMAGE
-            value: registry.opensuse.org/isv/suse/edge/lifecycle/containerfile/suse/release-manifest
+            value: registry.opensuse.org/isv/suse/edge/lifecycle/containerfile/release-manifest
           - name: SERVICE_ACCOUNT_NAME
             valueFrom:
               fieldRef:

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -72,6 +72,10 @@ spec:
                 fieldPath: metadata.namespace
           - name: RELEASE_MANIFEST_IMAGE
             value: registry.opensuse.org/isv/suse/edge/lifecycle/containerfile/release-manifest
+          - name: KUBECTL_IMAGE
+            value: registry.opensuse.org/isv/suse/edge/lifecycle/containerfile/kubectl
+          - name: KUBECTL_VERSION
+            value: 1.30.3
           - name: SERVICE_ACCOUNT_NAME
             valueFrom:
               fieldRef:

--- a/config/samples/lifecycle_v1alpha1_releasemanifest.yaml
+++ b/config/samples/lifecycle_v1alpha1_releasemanifest.yaml
@@ -4,16 +4,16 @@ metadata:
   labels:
     app.kubernetes.io/name: upgrade-controller
     app.kubernetes.io/managed-by: kustomize
-  name: releasemanifest-sample
+  name: release-manifest-3-1-0
   namespace: upgrade-controller-system
 spec:
-  releaseVersion: 3.0.1
+  releaseVersion: 3.1.0
   components:
     kubernetes:
       k3s:
-        version: v1.28.9+k3s1
+        version: v1.30.3+k3s1
       rke2:
-        version: v1.28.9+rke2r1
+        version: v1.30.3+rke2r1
     operatingSystem:
       version: "6.0"
       zypperID: "SL-Micro"

--- a/config/samples/lifecycle_v1alpha1_upgradeplan.yaml
+++ b/config/samples/lifecycle_v1alpha1_upgradeplan.yaml
@@ -7,4 +7,4 @@ metadata:
   name: upgradeplan-sample
   namespace: upgrade-controller-system
 spec:
-  releaseVersion: 3.0.1
+  releaseVersion: 3.1.0

--- a/internal/controller/release_manifest.go
+++ b/internal/controller/release_manifest.go
@@ -34,7 +34,14 @@ func (r *UpgradePlanReconciler) retrieveReleaseManifest(ctx context.Context, upg
 
 func (r *UpgradePlanReconciler) createReleaseManifest(ctx context.Context, upgradePlan *lifecyclev1alpha1.UpgradePlan) error {
 	annotations := upgrade.PlanIdentifierAnnotations(upgradePlan.Name, upgradePlan.Namespace)
-	job, err := upgrade.ReleaseManifestInstallJob(r.ReleaseManifestImage, upgradePlan.Spec.ReleaseVersion, r.ServiceAccount, upgradePlan.Namespace, annotations)
+	job, err := upgrade.ReleaseManifestInstallJob(
+		r.ReleaseManifestImage,
+		upgradePlan.Spec.ReleaseVersion,
+		r.KubectlImage,
+		r.KubectlVersion,
+		r.ServiceAccount,
+		upgradePlan.Namespace,
+		annotations)
 	if err != nil {
 		return err
 	}

--- a/internal/controller/release_manifest.go
+++ b/internal/controller/release_manifest.go
@@ -3,6 +3,7 @@ package controller
 import (
 	"context"
 	"fmt"
+	"strings"
 	"time"
 
 	lifecyclev1alpha1 "github.com/suse-edge/upgrade-controller/api/v1alpha1"
@@ -34,13 +35,11 @@ func (r *UpgradePlanReconciler) retrieveReleaseManifest(ctx context.Context, upg
 
 func (r *UpgradePlanReconciler) createReleaseManifest(ctx context.Context, upgradePlan *lifecyclev1alpha1.UpgradePlan) error {
 	annotations := upgrade.PlanIdentifierAnnotations(upgradePlan.Name, upgradePlan.Namespace)
-	job, err := upgrade.ReleaseManifestInstallJob(
-		r.ReleaseManifestImage,
-		upgradePlan.Spec.ReleaseVersion,
-		r.Kubectl,
-		r.ServiceAccount,
-		upgradePlan.Namespace,
-		annotations)
+	releaseManifest := upgrade.ContainerImage{
+		Name:    r.ReleaseManifestImage,
+		Version: strings.TrimPrefix(upgradePlan.Spec.ReleaseVersion, "v"),
+	}
+	job, err := upgrade.ReleaseManifestInstallJob(releaseManifest, r.Kubectl, r.ServiceAccount, upgradePlan.Namespace, annotations)
 	if err != nil {
 		return err
 	}

--- a/internal/controller/release_manifest.go
+++ b/internal/controller/release_manifest.go
@@ -37,8 +37,7 @@ func (r *UpgradePlanReconciler) createReleaseManifest(ctx context.Context, upgra
 	job, err := upgrade.ReleaseManifestInstallJob(
 		r.ReleaseManifestImage,
 		upgradePlan.Spec.ReleaseVersion,
-		r.KubectlImage,
-		r.KubectlVersion,
+		r.Kubectl,
 		r.ServiceAccount,
 		upgradePlan.Namespace,
 		annotations)

--- a/internal/controller/upgradeplan_controller.go
+++ b/internal/controller/upgradeplan_controller.go
@@ -55,6 +55,8 @@ type UpgradePlanReconciler struct {
 	Recorder             record.EventRecorder
 	ServiceAccount       string
 	ReleaseManifestImage string
+	KubectlImage         string
+	KubectlVersion       string
 }
 
 // +kubebuilder:rbac:groups=lifecycle.suse.com,resources=upgradeplans,verbs=get;list;watch;create;update;patch;delete

--- a/internal/controller/upgradeplan_controller.go
+++ b/internal/controller/upgradeplan_controller.go
@@ -55,8 +55,7 @@ type UpgradePlanReconciler struct {
 	Recorder             record.EventRecorder
 	ServiceAccount       string
 	ReleaseManifestImage string
-	KubectlImage         string
-	KubectlVersion       string
+	Kubectl              upgrade.ContainerImage
 }
 
 // +kubebuilder:rbac:groups=lifecycle.suse.com,resources=upgradeplans,verbs=get;list;watch;create;update;patch;delete

--- a/internal/upgrade/release_manifest.go
+++ b/internal/upgrade/release_manifest.go
@@ -9,7 +9,16 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-func ReleaseManifestInstallJob(releaseManifestImage, releaseManifestVersion, kubectlImage, kubectlVersion, serviceAccount, namespace string, annotations map[string]string) (*batchv1.Job, error) {
+type ContainerImage struct {
+	Name    string
+	Version string
+}
+
+func (image ContainerImage) String() string {
+	return fmt.Sprintf("%s:%s", image.Name, image.Version)
+}
+
+func ReleaseManifestInstallJob(releaseManifestImage, releaseManifestVersion string, kubectl ContainerImage, serviceAccount, namespace string, annotations map[string]string) (*batchv1.Job, error) {
 	if releaseManifestImage == "" {
 		return nil, fmt.Errorf("release manifest image is empty")
 	} else if releaseManifestVersion == "" {
@@ -55,7 +64,7 @@ func ReleaseManifestInstallJob(releaseManifestImage, releaseManifestVersion, kub
 					Containers: []corev1.Container{
 						{
 							Name:         workloadName,
-							Image:        fmt.Sprintf("%s:%s", kubectlImage, kubectlVersion),
+							Image:        kubectl.String(),
 							Args:         []string{"apply", "-f", releaseManifestPath},
 							VolumeMounts: []corev1.VolumeMount{volumeMount},
 						},

--- a/internal/upgrade/release_manifest.go
+++ b/internal/upgrade/release_manifest.go
@@ -18,16 +18,14 @@ func (image ContainerImage) String() string {
 	return fmt.Sprintf("%s:%s", image.Name, image.Version)
 }
 
-func ReleaseManifestInstallJob(releaseManifestImage, releaseManifestVersion string, kubectl ContainerImage, serviceAccount, namespace string, annotations map[string]string) (*batchv1.Job, error) {
-	if releaseManifestImage == "" {
+func ReleaseManifestInstallJob(releaseManifest, kubectl ContainerImage, serviceAccount, namespace string, annotations map[string]string) (*batchv1.Job, error) {
+	if releaseManifest.Name == "" {
 		return nil, fmt.Errorf("release manifest image is empty")
-	} else if releaseManifestVersion == "" {
+	} else if releaseManifest.Version == "" {
 		return nil, fmt.Errorf("release manifest version is empty")
 	}
 
-	releaseManifestVersion = strings.TrimPrefix(releaseManifestVersion, "v")
-	workloadName := fmt.Sprintf("apply-release-manifest-%s", strings.ReplaceAll(releaseManifestVersion, ".", "-"))
-	releaseManifestImage = fmt.Sprintf("%s:%s", releaseManifestImage, releaseManifestVersion)
+	workloadName := fmt.Sprintf("apply-release-manifest-%s", strings.ReplaceAll(releaseManifest.Version, ".", "-"))
 	ttl := int32(0)
 
 	volumeMount := corev1.VolumeMount{
@@ -56,7 +54,7 @@ func ReleaseManifestInstallJob(releaseManifestImage, releaseManifestVersion stri
 					InitContainers: []corev1.Container{
 						{
 							Name:         fmt.Sprintf("init-%s", workloadName),
-							Image:        releaseManifestImage,
+							Image:        releaseManifest.String(),
 							Command:      []string{"cp", "release_manifest.yaml", releaseManifestPath},
 							VolumeMounts: []corev1.VolumeMount{volumeMount},
 						},

--- a/internal/upgrade/release_manifest_test.go
+++ b/internal/upgrade/release_manifest_test.go
@@ -8,8 +8,10 @@ import (
 )
 
 func TestReleaseManifestInstallJob(t *testing.T) {
-	releaseImageName := "registry.suse.com/edge/release-manifest"
-	releaseImageVersion := "3.1.0"
+	releaseManifest := ContainerImage{
+		Name:    "registry.suse.com/edge/release-manifest",
+		Version: "3.1.0",
+	}
 	kubectl := ContainerImage{
 		Name:    "registry.suse.com/edge/kubectl",
 		Version: "1.30.3",
@@ -20,7 +22,7 @@ func TestReleaseManifestInstallJob(t *testing.T) {
 		"lifecycle.suse.com/x": "z",
 	}
 
-	job, err := ReleaseManifestInstallJob(releaseImageName, releaseImageVersion, kubectl, serviceAccount, namespace, annotations)
+	job, err := ReleaseManifestInstallJob(releaseManifest, kubectl, serviceAccount, namespace, annotations)
 	require.NoError(t, err)
 
 	assert.Equal(t, "batch/v1", job.TypeMeta.APIVersion)
@@ -68,12 +70,12 @@ func TestReleaseManifestInstallJob(t *testing.T) {
 	ttl := int32(0)
 	assert.Equal(t, &ttl, job.Spec.TTLSecondsAfterFinished)
 
-	job, err = ReleaseManifestInstallJob("", releaseImageVersion, kubectl, serviceAccount, namespace, annotations)
+	job, err = ReleaseManifestInstallJob(ContainerImage{Version: "3.1.0"}, kubectl, serviceAccount, namespace, annotations)
 	require.Error(t, err)
 	assert.EqualError(t, err, "release manifest image is empty")
 	assert.Nil(t, job)
 
-	job, err = ReleaseManifestInstallJob(releaseImageName, "", kubectl, serviceAccount, namespace, annotations)
+	job, err = ReleaseManifestInstallJob(ContainerImage{Name: "registry.suse.com/edge/release-manifest"}, kubectl, serviceAccount, namespace, annotations)
 	require.Error(t, err)
 	assert.EqualError(t, err, "release manifest version is empty")
 	assert.Nil(t, job)

--- a/internal/upgrade/release_manifest_test.go
+++ b/internal/upgrade/release_manifest_test.go
@@ -8,15 +8,17 @@ import (
 )
 
 func TestReleaseManifestInstallJob(t *testing.T) {
-	imageName := "registry.suse.com/edge/release-manifest"
-	imageVersion := "3.1.0"
+	releaseImageName := "registry.suse.com/edge/release-manifest"
+	releaseImageVersion := "3.1.0"
+	kubectlImageName := "registry.suse.com/edge/kubectl"
+	kubectlImageVersion := "1.30.3"
 	serviceAccount := "upgrade-controller-sa"
 	namespace := "upgrade-controller-ns"
 	annotations := map[string]string{
 		"lifecycle.suse.com/x": "z",
 	}
 
-	job, err := ReleaseManifestInstallJob(imageName, imageVersion, serviceAccount, namespace, annotations)
+	job, err := ReleaseManifestInstallJob(releaseImageName, releaseImageVersion, kubectlImageName, kubectlImageVersion, serviceAccount, namespace, annotations)
 	require.NoError(t, err)
 
 	assert.Equal(t, "batch/v1", job.TypeMeta.APIVersion)
@@ -30,12 +32,33 @@ func TestReleaseManifestInstallJob(t *testing.T) {
 	assert.Equal(t, "apply-release-manifest-3-1-0", job.Spec.Template.ObjectMeta.Name)
 	assert.Equal(t, "upgrade-controller-ns", job.Spec.Template.ObjectMeta.Namespace)
 
+	require.Len(t, job.Spec.Template.Spec.InitContainers, 1)
+
+	containerSpec := job.Spec.Template.Spec.InitContainers[0]
+	assert.Equal(t, "init-apply-release-manifest-3-1-0", containerSpec.Name)
+	assert.Equal(t, "registry.suse.com/edge/release-manifest:3.1.0", containerSpec.Image)
+	assert.Equal(t, []string{"cp", "release_manifest.yaml", "/release/manifest.yaml"}, containerSpec.Command)
+	assert.Empty(t, containerSpec.Args)
+
+	require.Len(t, containerSpec.VolumeMounts, 1)
+	assert.Equal(t, "release", containerSpec.VolumeMounts[0].Name)
+	assert.Equal(t, "/release", containerSpec.VolumeMounts[0].MountPath)
+
 	require.Len(t, job.Spec.Template.Spec.Containers, 1)
 
-	containerSpec := job.Spec.Template.Spec.Containers[0]
+	containerSpec = job.Spec.Template.Spec.Containers[0]
 	assert.Equal(t, "apply-release-manifest-3-1-0", containerSpec.Name)
-	assert.Equal(t, "registry.suse.com/edge/release-manifest:3.1.0", containerSpec.Image)
-	assert.Equal(t, []string{"apply", "-f", "release_manifest.yaml"}, containerSpec.Args)
+	assert.Equal(t, "registry.suse.com/edge/kubectl:1.30.3", containerSpec.Image)
+	assert.Empty(t, containerSpec.Command)
+	assert.Equal(t, []string{"apply", "-f", "/release/manifest.yaml"}, containerSpec.Args)
+
+	require.Len(t, containerSpec.VolumeMounts, 1)
+	assert.Equal(t, "release", containerSpec.VolumeMounts[0].Name)
+	assert.Equal(t, "/release", containerSpec.VolumeMounts[0].MountPath)
+
+	require.Len(t, job.Spec.Template.Spec.Volumes, 1)
+	assert.Equal(t, "release", job.Spec.Template.Spec.Volumes[0].Name)
+	assert.NotNil(t, job.Spec.Template.Spec.Volumes[0].EmptyDir)
 
 	assert.EqualValues(t, "OnFailure", job.Spec.Template.Spec.RestartPolicy)
 	assert.Equal(t, "upgrade-controller-sa", job.Spec.Template.Spec.ServiceAccountName)
@@ -43,12 +66,12 @@ func TestReleaseManifestInstallJob(t *testing.T) {
 	ttl := int32(0)
 	assert.Equal(t, &ttl, job.Spec.TTLSecondsAfterFinished)
 
-	job, err = ReleaseManifestInstallJob("", imageVersion, serviceAccount, namespace, annotations)
+	job, err = ReleaseManifestInstallJob("", releaseImageVersion, kubectlImageName, kubectlImageVersion, serviceAccount, namespace, annotations)
 	require.Error(t, err)
 	assert.EqualError(t, err, "release manifest image is empty")
 	assert.Nil(t, job)
 
-	job, err = ReleaseManifestInstallJob(imageName, "", serviceAccount, namespace, annotations)
+	job, err = ReleaseManifestInstallJob(releaseImageName, "", kubectlImageName, kubectlImageVersion, serviceAccount, namespace, annotations)
 	require.Error(t, err)
 	assert.EqualError(t, err, "release manifest version is empty")
 	assert.Nil(t, job)

--- a/internal/upgrade/release_manifest_test.go
+++ b/internal/upgrade/release_manifest_test.go
@@ -10,15 +10,17 @@ import (
 func TestReleaseManifestInstallJob(t *testing.T) {
 	releaseImageName := "registry.suse.com/edge/release-manifest"
 	releaseImageVersion := "3.1.0"
-	kubectlImageName := "registry.suse.com/edge/kubectl"
-	kubectlImageVersion := "1.30.3"
+	kubectl := ContainerImage{
+		Name:    "registry.suse.com/edge/kubectl",
+		Version: "1.30.3",
+	}
 	serviceAccount := "upgrade-controller-sa"
 	namespace := "upgrade-controller-ns"
 	annotations := map[string]string{
 		"lifecycle.suse.com/x": "z",
 	}
 
-	job, err := ReleaseManifestInstallJob(releaseImageName, releaseImageVersion, kubectlImageName, kubectlImageVersion, serviceAccount, namespace, annotations)
+	job, err := ReleaseManifestInstallJob(releaseImageName, releaseImageVersion, kubectl, serviceAccount, namespace, annotations)
 	require.NoError(t, err)
 
 	assert.Equal(t, "batch/v1", job.TypeMeta.APIVersion)
@@ -66,12 +68,12 @@ func TestReleaseManifestInstallJob(t *testing.T) {
 	ttl := int32(0)
 	assert.Equal(t, &ttl, job.Spec.TTLSecondsAfterFinished)
 
-	job, err = ReleaseManifestInstallJob("", releaseImageVersion, kubectlImageName, kubectlImageVersion, serviceAccount, namespace, annotations)
+	job, err = ReleaseManifestInstallJob("", releaseImageVersion, kubectl, serviceAccount, namespace, annotations)
 	require.Error(t, err)
 	assert.EqualError(t, err, "release manifest image is empty")
 	assert.Nil(t, job)
 
-	job, err = ReleaseManifestInstallJob(releaseImageName, "", kubectlImageName, kubectlImageVersion, serviceAccount, namespace, annotations)
+	job, err = ReleaseManifestInstallJob(releaseImageName, "", kubectl, serviceAccount, namespace, annotations)
 	require.Error(t, err)
 	assert.EqualError(t, err, "release manifest version is empty")
 	assert.Nil(t, job)


### PR DESCRIPTION
- Introduces an init container to copy the ReleaseManifest custom resources
- Adjusts the main container to apply the ReleaseManifest from the init copy