### PR TITLE
Reorder node validation

### DIFF
--- a/api/v1alpha1/releasemanifest_types.go
+++ b/api/v1alpha1/releasemanifest_types.go
@@ -28,6 +28,13 @@ const (
 	ArchTypeARM Arch = "aarch64"
 )
 
+var SupportedArchitectures = map[string]struct{}{
+	string(ArchTypeX86): {},
+	string(ArchTypeARM): {},
+	ArchTypeX86.Short(): {},
+	ArchTypeARM.Short(): {},
+}
+
 // ReleaseManifestSpec defines the desired state of ReleaseManifest
 type ReleaseManifestSpec struct {
 	ReleaseVersion string     `json:"releaseVersion"`

--- a/api/v1alpha1/upgradeplan_types.go
+++ b/api/v1alpha1/upgradeplan_types.go
@@ -26,6 +26,9 @@ import (
 const (
 	UpgradePlanFinalizer = "upgradeplan.lifecycle.suse.com/finalizer"
 
+	ValidationFailedCondition     = "ValidationFailed"
+	UnsupportedArchitectureReason = "UnsupportedArchitecture"
+
 	OperatingSystemUpgradedCondition = "OSUpgraded"
 	KubernetesUpgradedCondition      = "KubernetesUpgraded"
 

--- a/internal/controller/reconcile_kubernetes.go
+++ b/internal/controller/reconcile_kubernetes.go
@@ -16,13 +16,13 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-func (r *UpgradePlanReconciler) reconcileKubernetes(ctx context.Context, upgradePlan *lifecyclev1alpha1.UpgradePlan, kubernetes *lifecyclev1alpha1.Kubernetes) (ctrl.Result, error) {
+func (r *UpgradePlanReconciler) reconcileKubernetes(
+	ctx context.Context,
+	upgradePlan *lifecyclev1alpha1.UpgradePlan,
+	kubernetes *lifecyclev1alpha1.Kubernetes,
+	nodeList *corev1.NodeList,
+) (ctrl.Result, error) {
 	nameSuffix := upgradePlan.Status.SUCNameSuffix
-
-	nodeList := &corev1.NodeList{}
-	if err := r.List(ctx, nodeList); err != nil {
-		return ctrl.Result{}, fmt.Errorf("listing nodes: %w", err)
-	}
 
 	kubernetesVersion, err := targetKubernetesVersion(nodeList, kubernetes)
 	if err != nil {

--- a/internal/controller/reconcile_os.go
+++ b/internal/controller/reconcile_os.go
@@ -15,19 +15,15 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-func (r *UpgradePlanReconciler) reconcileOS(ctx context.Context, upgradePlan *lifecyclev1alpha1.UpgradePlan, releaseVersion string, releaseOS *lifecyclev1alpha1.OperatingSystem) (ctrl.Result, error) {
+func (r *UpgradePlanReconciler) reconcileOS(
+	ctx context.Context,
+	upgradePlan *lifecyclev1alpha1.UpgradePlan,
+	releaseVersion string,
+	releaseOS *lifecyclev1alpha1.OperatingSystem,
+	nodeList *corev1.NodeList,
+) (ctrl.Result, error) {
 	identifierAnnotations := upgrade.PlanIdentifierAnnotations(upgradePlan.Name, upgradePlan.Namespace)
 	nameSuffix := upgradePlan.Status.SUCNameSuffix
-
-	nodeList := &corev1.NodeList{}
-	if err := r.List(ctx, nodeList); err != nil {
-		return ctrl.Result{}, fmt.Errorf("listing nodes: %w", err)
-	}
-
-	if err := validateOSArch(nodeList, releaseOS.SupportedArchs); err != nil {
-		setFailedCondition(upgradePlan, lifecyclev1alpha1.OperatingSystemUpgradedCondition, "Cluster nodes are running unsupported architectures")
-		return ctrl.Result{}, fmt.Errorf("validating cluster node OS architecture: %w", err)
-	}
 
 	secret, err := upgrade.OSUpgradeSecret(nameSuffix, releaseOS, identifierAnnotations)
 	if err != nil {
@@ -116,22 +112,14 @@ func isOSUpgraded(nodeList *corev1.NodeList, selector labels.Selector, osPrettyN
 	return true
 }
 
-func validateOSArch(nodeList *corev1.NodeList, supportedArchs []lifecyclev1alpha1.Arch) error {
-	supportedArchMap := map[string]bool{}
-	for _, arch := range supportedArchs {
-		// add both the long and short architecture name
-		// to avoid any future problems related to changing
-		// what 'node.Status.NodeInfo.Architecture' outputs
-		supportedArchMap[string(arch)] = true
-		supportedArchMap[arch.Short()] = true
-	}
+func findUnsupportedNodes(nodeList *corev1.NodeList) []string {
+	var unsupported []string
 
 	for _, node := range nodeList.Items {
-		nodeArch := node.Status.NodeInfo.Architecture
-		if _, ok := supportedArchMap[nodeArch]; !ok {
-			return fmt.Errorf("unsupported arch '%s' for '%s' node. Supported archs: %s", nodeArch, node.Name, supportedArchs)
+		if _, ok := lifecyclev1alpha1.SupportedArchitectures[node.Status.NodeInfo.Architecture]; !ok {
+			unsupported = append(unsupported, node.Name)
 		}
 	}
 
-	return nil
+	return unsupported
 }

--- a/internal/controller/reconcile_os_test.go
+++ b/internal/controller/reconcile_os_test.go
@@ -4,85 +4,42 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	lifecyclev1alpha1 "github.com/suse-edge/upgrade-controller/api/v1alpha1"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 )
 
-func TestValidateOSArch(t *testing.T) {
-	validArchs := []lifecyclev1alpha1.Arch{
-		"x86_64",
-		"aarch64",
-	}
-
+func TestFindUnsupportedNodes(t *testing.T) {
 	nodes := &corev1.NodeList{
 		Items: []corev1.Node{
 			{
 				ObjectMeta: metav1.ObjectMeta{Name: "node1"},
-				Status:     corev1.NodeStatus{NodeInfo: corev1.NodeSystemInfo{Architecture: "arm64"}},
+				Status:     corev1.NodeStatus{NodeInfo: corev1.NodeSystemInfo{Architecture: "x86"}},
 			},
 			{
 				ObjectMeta: metav1.ObjectMeta{Name: "node2"},
-				Status:     corev1.NodeStatus{NodeInfo: corev1.NodeSystemInfo{Architecture: "aarch64"}},
-			},
-			{
-				ObjectMeta: metav1.ObjectMeta{Name: "node3"},
-				Status:     corev1.NodeStatus{NodeInfo: corev1.NodeSystemInfo{Architecture: "amd64"}},
-			},
-			{
-				ObjectMeta: metav1.ObjectMeta{Name: "node4"},
-				Status:     corev1.NodeStatus{NodeInfo: corev1.NodeSystemInfo{Architecture: "x86_64"}},
-			},
-		}}
-
-	assert.NoError(t, validateOSArch(nodes, validArchs))
-}
-
-func TestValidateOSArch_InvalidArch(t *testing.T) {
-	archs := []lifecyclev1alpha1.Arch{
-		"x86_64",
-		"risc-v",
-	}
-
-	assert.PanicsWithValue(t, "unknown arch: risc-v", func() {
-		_ = validateOSArch(nil, archs)
-	})
-}
-
-func TestValidateOSArch_UnsupportedNode(t *testing.T) {
-	validArchs := []lifecyclev1alpha1.Arch{
-		"x86_64",
-		"aarch64",
-	}
-
-	nodes := &corev1.NodeList{
-		Items: []corev1.Node{
-			{
-				ObjectMeta: metav1.ObjectMeta{Name: "node1"},
 				Status:     corev1.NodeStatus{NodeInfo: corev1.NodeSystemInfo{Architecture: "arm64"}},
 			},
 			{
-				ObjectMeta: metav1.ObjectMeta{Name: "node2"},
+				ObjectMeta: metav1.ObjectMeta{Name: "node3"},
 				Status:     corev1.NodeStatus{NodeInfo: corev1.NodeSystemInfo{Architecture: "aarch64"}},
 			},
 			{
-				ObjectMeta: metav1.ObjectMeta{Name: "node3"},
-				Status:     corev1.NodeStatus{NodeInfo: corev1.NodeSystemInfo{Architecture: "amd64"}},
-			},
-			{
 				ObjectMeta: metav1.ObjectMeta{Name: "node4"},
-				Status:     corev1.NodeStatus{NodeInfo: corev1.NodeSystemInfo{Architecture: "x86_64"}},
+				Status:     corev1.NodeStatus{NodeInfo: corev1.NodeSystemInfo{Architecture: "risc-v"}},
 			},
 			{
 				ObjectMeta: metav1.ObjectMeta{Name: "node5"},
-				Status:     corev1.NodeStatus{NodeInfo: corev1.NodeSystemInfo{Architecture: "risc-v"}},
+				Status:     corev1.NodeStatus{NodeInfo: corev1.NodeSystemInfo{Architecture: "amd64"}},
+			},
+			{
+				ObjectMeta: metav1.ObjectMeta{Name: "node6"},
+				Status:     corev1.NodeStatus{NodeInfo: corev1.NodeSystemInfo{Architecture: "x86_64"}},
 			},
 		}}
 
-	assert.EqualError(t, validateOSArch(nodes, validArchs),
-		"unsupported arch 'risc-v' for 'node5' node. Supported archs: [x86_64 aarch64]")
+	assert.Equal(t, []string{"node1", "node4"}, findUnsupportedNodes(nodes))
 }
 
 func TestIsOSUpgraded(t *testing.T) {


### PR DESCRIPTION
- Executes node architecture validation first in order not to block executing upgrades
- Moves supported architectures definition to the v1alpha1 package
- Introduces a ValidationFailed condition