### PR TITLE
Fix release manifest image path

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -59,7 +59,7 @@ func init() {
 }
 
 const (
-	defaultReleaseManifestImage = "registry.opensuse.org/isv/suse/edge/lifecycle/containerfile/suse/release-manifest"
+	defaultReleaseManifestImage = "registry.opensuse.org/isv/suse/edge/lifecycle/containerfile/release-manifest"
 	defaultKubectlImage         = "registry.opensuse.org/isv/suse/edge/lifecycle/containerfile/kubectl"
 	defaultKubectlVersion       = "1.30.3"
 )


### PR DESCRIPTION
- The build tag for the release manifest container image now no longer uses the `suse/` prefix
- This is the only incorrect occurrence in the codebase