### PR TITLE
Use a non-concurrent approach to Kubernetes worker upgrades

### DIFF
--- a/internal/upgrade/kubernetes.go
+++ b/internal/upgrade/kubernetes.go
@@ -85,7 +85,7 @@ func KubernetesWorkerPlan(nameSuffix, version string, drain bool, annotations ma
 	workerPlan.Labels = map[string]string{
 		"k8s-upgrade": "worker",
 	}
-	workerPlan.Spec.Concurrency = 2
+	workerPlan.Spec.Concurrency = 1
 	workerPlan.Spec.NodeSelector = &metav1.LabelSelector{
 		MatchExpressions: []metav1.LabelSelectorRequirement{
 			{

--- a/internal/upgrade/kubernetes_test.go
+++ b/internal/upgrade/kubernetes_test.go
@@ -171,7 +171,7 @@ func TestKubernetesWorkerPlan_RKE2(t *testing.T) {
 	assert.Empty(t, upgradeContainer.Args)
 
 	assert.Equal(t, version, upgradePlan.Spec.Version)
-	assert.EqualValues(t, 2, upgradePlan.Spec.Concurrency)
+	assert.EqualValues(t, 1, upgradePlan.Spec.Concurrency)
 	assert.True(t, upgradePlan.Spec.Cordon)
 
 	assert.Equal(t, "system-upgrade-controller", upgradePlan.Spec.ServiceAccountName)
@@ -219,7 +219,7 @@ func TestKubernetesWorkerPlan_K3s(t *testing.T) {
 	assert.Empty(t, upgradeContainer.Args)
 
 	assert.Equal(t, version, upgradePlan.Spec.Version)
-	assert.EqualValues(t, 2, upgradePlan.Spec.Concurrency)
+	assert.EqualValues(t, 1, upgradePlan.Spec.Concurrency)
 	assert.True(t, upgradePlan.Spec.Cordon)
 
 	assert.Equal(t, "system-upgrade-controller", upgradePlan.Spec.ServiceAccountName)


### PR DESCRIPTION
We've identified that we run into some issues when upgrading the Kubernetes versions on worker nodes. In the future, we'd like to revisit this and enable _faster_ upgrades, however, going for a non-concurrent approach for these upgrades seem to be the safer option in the short term.