### PR TITLE
Fix OS migration bug

### DIFF
--- a/api/v1alpha1/releasemanifest_types.go
+++ b/api/v1alpha1/releasemanifest_types.go
@@ -100,10 +100,9 @@ type KubernetesDistribution struct {
 }
 
 type OperatingSystem struct {
-	Version     string `json:"version"`
-	ZypperID    string `json:"zypperID"`
-	CPEScheme   string `json:"cpeScheme"`
-	RepoGPGPath string `json:"repoGPGPath"`
+	Version   string `json:"version"`
+	ZypperID  string `json:"zypperID"`
+	CPEScheme string `json:"cpeScheme"`
 	// +kubebuilder:validation:MinItems=1
 	SupportedArchs []Arch `json:"supportedArchs"`
 	PrettyName     string `json:"prettyName"`

--- a/config/crd/bases/lifecycle.suse.com_releasemanifests.yaml
+++ b/config/crd/bases/lifecycle.suse.com_releasemanifests.yaml
@@ -67,8 +67,6 @@ spec:
                         type: string
                       prettyName:
                         type: string
-                      repoGPGPath:
-                        type: string
                       supportedArchs:
                         items:
                           enum:
@@ -84,7 +82,6 @@ spec:
                     required:
                     - cpeScheme
                     - prettyName
-                    - repoGPGPath
                     - supportedArchs
                     - version
                     - zypperID

--- a/config/samples/lifecycle_v1alpha1_releasemanifest.yaml
+++ b/config/samples/lifecycle_v1alpha1_releasemanifest.yaml
@@ -18,7 +18,6 @@ spec:
       version: "6.0"
       zypperID: "SL-Micro"
       cpeScheme: "cpe:/o:suse:sl-micro:6.0"
-      repoGPGPath: "/usr/lib/rpm/gnupg/keys/gpg-pubkey-09d9ea69-645b99ce.asc"
       prettyName: "SUSE Linux Micro 6.0"
       supportedArchs:
         - "x86_64"

--- a/helm/upgrade-controller/charts/lifecycle-crds/templates/release-manifest-crd.yaml
+++ b/helm/upgrade-controller/charts/lifecycle-crds/templates/release-manifest-crd.yaml
@@ -65,8 +65,6 @@ spec:
                           type: string
                         prettyName:
                           type: string
-                        repoGPGPath:
-                          type: string
                         supportedArchs:
                           items:
                             enum:
@@ -82,7 +80,6 @@ spec:
                       required:
                         - cpeScheme
                         - prettyName
-                        - repoGPGPath
                         - supportedArchs
                         - version
                         - zypperID

--- a/internal/upgrade/os.go
+++ b/internal/upgrade/os.go
@@ -34,15 +34,13 @@ func OSUpgradeSecret(nameSuffix string, releaseOS *lifecyclev1alpha1.OperatingSy
 	}
 
 	values := struct {
-		CPEScheme  string
-		RepoGPGKey string
-		ZypperID   string
-		Version    string
+		CPEScheme string
+		ZypperID  string
+		Version   string
 	}{
-		CPEScheme:  releaseOS.CPEScheme,
-		RepoGPGKey: releaseOS.RepoGPGPath,
-		ZypperID:   releaseOS.ZypperID,
-		Version:    releaseOS.Version,
+		CPEScheme: releaseOS.CPEScheme,
+		ZypperID:  releaseOS.ZypperID,
+		Version:   releaseOS.Version,
 	}
 
 	var buff bytes.Buffer

--- a/internal/upgrade/os_test.go
+++ b/internal/upgrade/os_test.go
@@ -16,10 +16,9 @@ const (
 
 func TestOSUpgradeSecret(t *testing.T) {
 	os := &lifecyclev1alpha1.OperatingSystem{
-		Version:     "6.0",
-		ZypperID:    "SL-Micro",
-		CPEScheme:   "some-cpe-scheme",
-		RepoGPGPath: "some-gpg-path",
+		Version:   "6.0",
+		ZypperID:  "SL-Micro",
+		CPEScheme: "some-cpe-scheme",
 	}
 	annotations := map[string]string{
 		"lifecycle.suse.com/x": "z",
@@ -42,8 +41,7 @@ func TestOSUpgradeSecret(t *testing.T) {
 	require.NotEmpty(t, scriptContents)
 
 	assert.Contains(t, scriptContents, "RELEASE_CPE=some-cpe-scheme")
-	assert.Contains(t, scriptContents, "/usr/sbin/transactional-update --continue run rpm --import some-gpg-path")
-	assert.Contains(t, scriptContents, "/usr/sbin/transactional-update --continue run zypper migration --non-interactive --product SL-Micro/6.0/${SYSTEM_ARCH} --root /")
+	assert.Contains(t, scriptContents, "/usr/sbin/transactional-update --continue run zypper migration --gpg-auto-import-keys --non-interactive --product SL-Micro/6.0/${SYSTEM_ARCH} --root /")
 }
 
 func TestOSControlPlanePlan(t *testing.T) {

--- a/internal/upgrade/templates/os-upgrade.sh.tpl
+++ b/internal/upgrade/templates/os-upgrade.sh.tpl
@@ -37,8 +37,7 @@ executeUpgrade(){
     else
         # Migration if the CPEs are different
         EXEC_START_PRE_PKG_UPGRADE="ExecStartPre=/usr/sbin/transactional-update cleanup up"
-        EXEC_START_PRE_RPM_IMPORT="ExecStartPre=/usr/sbin/transactional-update --continue run rpm --import {{.RepoGPGKey}}"
-        EXEC_START_PRE_LINES=$(echo -e "${EXEC_START_PRE_PKG_UPGRADE}\n${EXEC_START_PRE_RPM_IMPORT}")
+        EXEC_START_PRE_LINES=$(echo -e "${EXEC_START_PRE_PKG_UPGRADE}")
 
         EXEC_START="/usr/sbin/transactional-update --continue run zypper migration --gpg-auto-import-keys --non-interactive --product {{.ZypperID}}/{{.Version}}/${SYSTEM_ARCH} --root /"
         SERVICE_NAME="os-migration.service"

--- a/internal/upgrade/templates/os-upgrade.sh.tpl
+++ b/internal/upgrade/templates/os-upgrade.sh.tpl
@@ -40,7 +40,7 @@ executeUpgrade(){
         EXEC_START_PRE_RPM_IMPORT="ExecStartPre=/usr/sbin/transactional-update --continue run rpm --import {{.RepoGPGKey}}"
         EXEC_START_PRE_LINES=$(echo -e "${EXEC_START_PRE_PKG_UPGRADE}\n${EXEC_START_PRE_RPM_IMPORT}")
 
-        EXEC_START="/usr/sbin/transactional-update --continue run zypper migration --non-interactive --product {{.ZypperID}}/{{.Version}}/${SYSTEM_ARCH} --root /"
+        EXEC_START="/usr/sbin/transactional-update --continue run zypper migration --gpg-auto-import-keys --non-interactive --product {{.ZypperID}}/{{.Version}}/${SYSTEM_ARCH} --root /"
         SERVICE_NAME="os-migration.service"
     fi
 

--- a/internal/upgrade/templates/os-upgrade.sh.tpl
+++ b/internal/upgrade/templates/os-upgrade.sh.tpl
@@ -26,20 +26,18 @@ executeUpgrade(){
     CURRENT_CPE=`cat /etc/os-release | grep -w CPE_NAME | cut -d "=" -f 2 | tr -d '"'`
 
     SYSTEM_ARCH=`arch`
-    # Lines that will be appended to the systemd.service 'ExecStartPre' configuration
-    EXEC_START_PRE_LINES=""
 
     # Determine whether this is a package update or a migration
     if [ "${RELEASE_CPE}" == "${CURRENT_CPE}" ]; then
         # Package update if both CPEs are the same
-        EXEC_START="/usr/sbin/transactional-update cleanup up"
+        EXEC_START="ExecStart=/usr/sbin/transactional-update cleanup up"
         SERVICE_NAME="os-pkg-update.service"
     else
         # Migration if the CPEs are different
-        EXEC_START_PRE_PKG_UPGRADE="ExecStartPre=/usr/sbin/transactional-update cleanup up"
-        EXEC_START_PRE_LINES=$(echo -e "${EXEC_START_PRE_PKG_UPGRADE}")
+        PKG_UPDATE_CMD="ExecStart=/usr/sbin/transactional-update cleanup up"
+        MIGRATION_CMD="ExecStart=/usr/sbin/transactional-update --continue run zypper migration --gpg-auto-import-keys --non-interactive --product {{.ZypperID}}/{{.Version}}/${SYSTEM_ARCH} --root /"
 
-        EXEC_START="/usr/sbin/transactional-update --continue run zypper migration --gpg-auto-import-keys --non-interactive --product {{.ZypperID}}/{{.Version}}/${SYSTEM_ARCH} --root /"
+        EXEC_START=$(echo -e "${PKG_UPDATE_CMD}\n${MIGRATION_CMD}")
         SERVICE_NAME="os-migration.service"
     fi
 
@@ -59,10 +57,9 @@ After=network.target
 
 [Service]
 Type=oneshot
-${EXEC_START_PRE_LINES:+$EXEC_START_PRE_LINES
-}ExecStart=${EXEC_START}
 IOSchedulingClass=best-effort
 IOSchedulingPriority=7
+${EXEC_START}
 EOF
 
     echo "Starting ${SERVICE_NAME}..."


### PR DESCRIPTION
closes: #93 

With the new `suseconnect-ng` version, we can now utilise the `--gpg-auto-import-keys` flag of the `zypper migration` command.

This means that:
1. We no longer need the `gpgRepoPath` property, as with `--gpg-auto-import-keys` flag we automatically import the key
2. Third-party repositories are added automatically as well which closes #93.

Examples with new functionality, where the node has the following third-party repositories:
```bash
zypper ar https://download.opensuse.org/repositories/SUSE:/CA/SLE_15_SP5 opensuse-ca
zypper ar https://download.nvidia.com/suse/sle15sp5/ nvidia
```

Automatically imported repo keys for the 6.0 SL Micro repo + `nvidia` and `opensuse-ca`:
```bash
Retrieving repository 'SL-Micro-6.0-Pool' metadata [......

Automatically importing the following key:

  Repository:       SL-Micro-6.0-Pool
  Key Fingerprint:  1C59 D66F CD52 563A 1693 3DBC FEC2 8EAF 09D9 EA69
  Key Name:         ALP Package Signing Key <build-alp@suse.de>
  Key Algorithm:    RSA 4096
  Key Created:      Wed May 10 13:19:10 2023
  Key Expires:      Sun May  9 13:19:10 2027
  Rpm Name:         gpg-pubkey-09d9ea69-645b99ce



    Note: A GPG pubkey is clearly identified by its fingerprint. Do not rely on the key's name. If
    you are not sure whether the presented key is authentic, ask the repository provider or check
    their web site. Many providers maintain a web page showing the fingerprints of the GPG keys they
    are using.
............done]
Forcing building of repository cache
Building repository 'SL-Micro-6.0-Pool' cache [....done]
Forcing raw metadata refresh
Retrieving repository 'nvidia' metadata [....

Automatically importing the following key:

  Repository:       nvidia
  Key Fingerprint:  2FB0 3195 DECD 4949 2BD1 C17A B1D0 D788 DB27 FD5A
  Key Name:         NVIDIA Linux Driver Team <linux-bugs@nvidia.com>
  Key Algorithm:    RSA 4096
  Key Created:      Thu Apr 14 22:04:01 2022
  Key Expires:      (does not expire)
  Rpm Name:         gpg-pubkey-db27fd5a-62589a51



    Note: A GPG pubkey is clearly identified by its fingerprint. Do not rely on the key's name. If
    you are not sure whether the presented key is authentic, ask the repository provider or check
    their web site. Many providers maintain a web page showing the fingerprints of the GPG keys they
    are using.
..done]
Forcing building of repository cache
Building repository 'nvidia' cache [....done]
Forcing raw metadata refresh
Retrieving repository 'opensuse-ca' metadata [...........

Automatically importing the following key:

  Repository:       opensuse-ca
  Key Fingerprint:  511A C9AC EC2F 2372 BBBE E05D 1B99 3C94 1BE9 1FF0
  Key Name:         SUSE:CA OBS Project <SUSE:CA@build.opensuse.org>
  Key Algorithm:    RSA 4096
  Key Created:      Fri Feb 24 12:52:37 2023
  Key Expires:      Sun May  4 12:52:36 2025
  Rpm Name:         gpg-pubkey-1be91ff0-63f8b315



    Note: A GPG pubkey is clearly identified by its fingerprint. Do not rely on the key's name. If
    you are not sure whether the presented key is authentic, ask the repository provider or check
    their web site. Many providers maintain a web page showing the fingerprints of the GPG keys they
    are using.
.done]
Forcing building of repository cache
Building repository 'opensuse-ca' cache [....done]
All repositories have been refreshed.
```