### PR TITLE
Query Helm charts in all namespaces

### DIFF
--- a/internal/controller/helm.go
+++ b/internal/controller/helm.go
@@ -230,7 +230,7 @@ func (r *UpgradePlanReconciler) upgradeHelmChart(
 
 	chartResource, err := findChartResource(chartResources, releaseChart.ReleaseName)
 	if err != nil {
-		return upgrade.ChartStateUnknown, fmt.Errorf("finding chart resource: %w", err)
+		return upgrade.ChartStateFailed, fmt.Errorf("finding chart resource: %w", err)
 	}
 
 	if chartResource == nil {

--- a/internal/controller/helm.go
+++ b/internal/controller/helm.go
@@ -230,7 +230,7 @@ func (r *UpgradePlanReconciler) upgradeHelmChart(
 
 	chartResource, err := findChartResource(chartResources, releaseChart.ReleaseName)
 	if err != nil {
-		return upgrade.ChartStateFailed, fmt.Errorf("finding chart resource: %w", err)
+		return upgrade.ChartStateFailed, err
 	}
 
 	if chartResource == nil {
@@ -251,7 +251,7 @@ func (r *UpgradePlanReconciler) upgradeHelmChart(
 	}
 
 	job := &batchv1.Job{}
-	if err = r.Get(ctx, types.NamespacedName{Name: chartResource.Status.JobName, Namespace: upgrade.HelmChartNamespace}, job); err != nil {
+	if err = r.Get(ctx, types.NamespacedName{Name: chartResource.Status.JobName, Namespace: chartResource.Namespace}, job); err != nil {
 		return upgrade.ChartStateUnknown, client.IgnoreNotFound(err)
 	}
 
@@ -294,7 +294,7 @@ func findChartResource(helmCharts *helmcattlev1.HelmChartList, name string) (*he
 	case 1:
 		return &charts[0], nil
 	default:
-		return nil, fmt.Errorf("more than one HelmChart resource with name '%s' exists", name)
+		return nil, errMultipleHelmChartResources
 	}
 }
 

--- a/internal/controller/reconcile_helm.go
+++ b/internal/controller/reconcile_helm.go
@@ -102,11 +102,11 @@ func (r *UpgradePlanReconciler) reconcileHelmChart(ctx context.Context, upgradeP
 }
 
 func findChartResource(helmCharts *helmcattlev1.HelmChartList, name string) (*helmcattlev1.HelmChart, error) {
-	var charts []*helmcattlev1.HelmChart
+	var charts []helmcattlev1.HelmChart
 
 	for _, chart := range helmCharts.Items {
 		if chart.Name == name {
-			charts = append(charts, &chart)
+			charts = append(charts, chart)
 		}
 	}
 
@@ -114,7 +114,7 @@ func findChartResource(helmCharts *helmcattlev1.HelmChartList, name string) (*he
 	case 0:
 		return nil, nil
 	case 1:
-		return charts[0], nil
+		return &charts[0], nil
 	default:
 		return nil, fmt.Errorf("more than one HelmChart resource with name '%s' exists", name)
 	}

--- a/internal/controller/upgradeplan_controller.go
+++ b/internal/controller/upgradeplan_controller.go
@@ -356,7 +356,7 @@ func (r *UpgradePlanReconciler) findUpgradePlanFromJob(ctx context.Context, job 
 	}
 
 	helmChart := &helmcattlev1.HelmChart{}
-	if err := r.Get(ctx, upgrade.ChartNamespacedName(chartName), helmChart); err != nil {
+	if err := r.Get(ctx, types.NamespacedName{Name: chartName, Namespace: job.GetNamespace()}, helmChart); err != nil {
 		logger := log.FromContext(ctx)
 		logger.Error(err, "failed to get helm chart")
 

--- a/internal/upgrade/helm.go
+++ b/internal/upgrade/helm.go
@@ -2,16 +2,7 @@ package upgrade
 
 import (
 	"fmt"
-
-	"k8s.io/apimachinery/pkg/types"
 )
-
-func ChartNamespacedName(chart string) types.NamespacedName {
-	return types.NamespacedName{
-		Name:      chart,
-		Namespace: HelmChartNamespace,
-	}
-}
 
 type HelmChartState int
 


### PR DESCRIPTION
Results in the following when multiple `HelmChart` resources are detected:
```
    Last Transition Time:           2024-10-25T17:45:40Z
    Message:                        Unable to upgrade Helm release 'neuvector' backed by multiple HelmChart resources
    Reason:                         Failed
    Status:                         False
    Type:                           NeuVectorUpgraded
```