### PR TITLE
Reduce concurrency for OS SUC workers

### DIFF
--- a/internal/upgrade/os.go
+++ b/internal/upgrade/os.go
@@ -114,7 +114,7 @@ func OSWorkerPlan(nameSuffix, releaseVersion, secretName string, releaseOS *life
 
 	labels["os-upgrade"] = "worker"
 	workerPlan := baseOSPlan(workerPlanName, releaseVersion, secretName, drain, labels)
-	workerPlan.Spec.Concurrency = 2
+	workerPlan.Spec.Concurrency = 1
 	workerPlan.Spec.NodeSelector = &metav1.LabelSelector{
 		MatchExpressions: []metav1.LabelSelectorRequirement{
 			{


### PR DESCRIPTION
Having concurrency for OS SUC Plans greater than **one** runs the risk of unexpected `kubectl drain` blockages.